### PR TITLE
'Create Quest' GUI option (w/ reusable screen changing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,25 @@
-# Dependencies
+# What You Need To Develop: 'Dependencies'
 - Maven (mvn)
     - Current build command: ``mvn -f [path/to/plugin/root/directory] clean package -U -e``
 - Java (openjdk-17)
 
-# Specification
+# How To Get Functionality: 'Actions'
+###### How pre-defined but flexible functionality is actually associated with buttons and other behaviours.
+Realistically 'Quest Actions' won't ever have to be called by their function names. It would just be from a list in the quest builder UI/UX. But when creating GUI template files (usually with 'Meta Actions' or 'Functions') there isn't much option to select from a list of actions, so here is a list for devs or if you're a very brave user.
+
+###### Meta Actions (Functions)
+| Function (How to refer to) | Parameters (How to customise)               | Purpose (What it aims to do)                                      |
+|----------------------------|---------------------------------------------|-------------------------------------------------------------------|
+| metaUpdateScreenFile       | 1: the template filename (without .json)    | dynamically change the current GUI screen to a different template |
+| metaUpdateScreen           | 1: the template expression (as json string) | dynamically change the current GUI screen to a different template |
+|                            |                                             |                                                                   |
+
+###### Quest Actions (Actions)
+| Function | Params | Purpose |
+|----------|--------|---------|
+| N/A      | 1: N/A | N/A     |
+
+# How It All Works: 'Specification'
 ###### the way to visualise/think about, and implement the program.
 Each <ins>quest</ins> is a <ins>container of stages</ins>. Each <ins>stage</ins> is a <ins>container of actions</ins> from the quest/NPC perspective (actions can also be stacked). Stages are all the things which occur. See examples in the table:
 
@@ -64,8 +80,11 @@ Where all the manually generated GUI screens are (src/main/resources/gui/screens
             "functions": [
                 { "name": String, "params": [] },
                 { "name": String, "params": [] }
+            ],
+            "actions": [
+                { "name": String, "params": [] }
             ]
         }
     ]
-  }
+}
 ```

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ Realistically 'Quest Actions' won't ever have to be called by their function nam
 |----------------------------|---------------------------------------------|-------------------------------------------------------------------|
 | metaUpdateScreenFile       | 1: the template filename (without .json)    | dynamically change the current GUI screen to a different template |
 | metaUpdateScreen           | 1: the template expression (as json string) | dynamically change the current GUI screen to a different template |
-|                            |                                             |                                                                   |
 
 ###### Quest Actions (Actions)
 | Function | Params | Purpose |

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# What You Need To Develop: 'Dependencies'
+# How To Develop: 'Dependencies'
 - Maven (mvn)
     - Current build command: ``mvn -f [path/to/plugin/root/directory] clean package -U -e``
 - Java (openjdk-17)

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Realistically 'Quest Actions' won't ever have to be called by their function nam
 ###### Meta Actions (Functions)
 | Function (How to refer to) | Parameters (How to customise)               | Purpose (What it aims to do)                                      |
 |----------------------------|---------------------------------------------|-------------------------------------------------------------------|
-| metaUpdateScreenFile       | 1: the template filename (without .json)    | dynamically change the current GUI screen to a different template |
-| metaUpdateScreen           | 1: the template expression (as json string) | dynamically change the current GUI screen to a different template |
+| UpdateScreenFile           | 1: the template filename (without .json)    | dynamically change the current GUI screen to a different template |
+| UpdateScreen               | 1: the template expression (as json string) | dynamically change the current GUI screen to a different template |
 
 ###### Quest Actions (Actions)
 | Function | Params | Purpose |

--- a/src/main/java/playerquests/Core.java
+++ b/src/main/java/playerquests/Core.java
@@ -1,5 +1,6 @@
 package playerquests;
 
+import org.bukkit.plugin.Plugin; // export the plugin for use elsewhere
 import org.bukkit.plugin.java.JavaPlugin; // essential for initialising the plugin
 import playerquests.chat.command.Commandplayerquest; // used to show the plugin as a GUI
 
@@ -14,9 +15,26 @@ import playerquests.chat.command.Commandplayerquest; // used to show the plugin 
  */
 public class Core extends JavaPlugin {
 
+    private static Plugin plugin;
+
+    /**
+     * Core class, to be instantiated by server.
+     */
+    public Core() {}
+
     @Override
     public void onEnable() {
+        plugin = this;
+
         // TODO: automatically initiate the commands
         new Commandplayerquest();
+    }
+
+    /**
+     * Mechanism to make the Plugin accessible for other classes.
+     * @return the main plugin instance
+     */
+    public static Plugin getPlugin() {
+        return plugin;
     }
 }

--- a/src/main/java/playerquests/chat/Chat.java
+++ b/src/main/java/playerquests/chat/Chat.java
@@ -1,5 +1,12 @@
 package playerquests.chat;
 
+/**
+ * Main class for everything to do with the in-game chat.
+ */
 public class Chat {
     
+    /**
+     * Constructs an empty Chat instance.
+     */
+    public Chat() {}
 }

--- a/src/main/java/playerquests/chat/command/Commandplayerquest.java
+++ b/src/main/java/playerquests/chat/command/Commandplayerquest.java
@@ -12,6 +12,9 @@ import playerquests.quest.Quest;
  */
 public class Commandplayerquest extends ChatCommand {
     
+    /**
+     * Loads the /playerquests command.
+     */
     public Commandplayerquest() {
         super("playerquests");
     }

--- a/src/main/java/playerquests/gui/GUI.java
+++ b/src/main/java/playerquests/gui/GUI.java
@@ -44,7 +44,7 @@ public class GUI {
         // default inventory
         this.inventory = Bukkit.createInventory(this.humanEntity, this.size);
 
-        // disallow taking slot items from GUI
+        // register listening to when gui events occur
         Bukkit.getPluginManager().registerEvents(this.guiListener, Core.getPlugin());
     }
 

--- a/src/main/java/playerquests/gui/GUI.java
+++ b/src/main/java/playerquests/gui/GUI.java
@@ -44,6 +44,9 @@ public class GUI {
         // default inventory
         this.inventory = Bukkit.createInventory(this.humanEntity, this.size);
 
+        // default title 
+        this.title = "";
+
         // register listening to when gui events occur
         Bukkit.getPluginManager().registerEvents(this.guiListener, Core.getPlugin());
     }
@@ -97,9 +100,9 @@ public class GUI {
      * @see #dispose() for unloading GUI on the backend.
      */
     public void close() {
-        this.dispose(); // unload GUI on the backend
-
         this.inventoryView.close(); // close GUI on the frontend.
+
+        this.dispose(); // unload GUI on the backend
     }
 
     /**

--- a/src/main/java/playerquests/gui/GUI.java
+++ b/src/main/java/playerquests/gui/GUI.java
@@ -1,6 +1,6 @@
 package playerquests.gui;
 
-import java.util.ArrayList; // Used to hold and manage info about the GUI slots
+import java.util.HashMap; // Used to hold and manage info about the GUI slots
 
 import org.bukkit.Bukkit; // used to refer to base spigot/bukkit methods
 import org.bukkit.ChatColor; // used to customise all kinds of in-game text
@@ -37,8 +37,8 @@ public class GUI {
     private InventoryView inventoryView; // the screen itself when open
     private String title = ""; // the title of the screen (InventoryView)
     private Integer size = 9; // the amount of slots in the GUI screen (Inventory)
-    private ArrayList<GUISlot> slots = new ArrayList<GUISlot>(); // the list of each slot with their own unique options
     private GUIListener guiListener = new GUIListener(this);
+    private HashMap<Integer, GUISlot> slots = new HashMap<Integer, GUISlot>();
 
     {
         // default inventory
@@ -134,8 +134,7 @@ public class GUI {
      * </ul>
      */
     private void buildSlots() {
-        this.slots.iterator().forEachRemaining(slot -> {
-            Integer position = slot.getSlot(); // for setting the slot position
+        this.slots.forEach((position, slot) -> {
             ItemStack item = GUIUtils.toItemStack(slot.getItem()); // for setting the slot item
             ItemMeta itemMeta = item.getItemMeta(); // for editing the slot meta such as label
             String errorLabel = "(Error)";
@@ -167,17 +166,55 @@ public class GUI {
     /**
      * Creates a new slot within the GUI system.
      * <p>
+     * Where the position of the slot is it's key.
+     * <p>
      * To address the complexity of the slots array and how slots can be comprised
      * of many parts, this method instantiates a whole new {@link GUISlot} class.
      * Each new GUISlot instance is added to a list in the {@link GUI} 
      * class. This list serves as a centralized repository, ensuring easy access to slot 
      * information when building/opening the GUI.
+     * @param position the inventory position this slot is
+     * @return a new (and tracked!) instance of GUISlot
+     */
+    public GUISlot newSlot(Integer position) {
+        GUISlot newSlot = new GUISlot(this, position);
+        this.slots.put(position, newSlot);
+        return newSlot;
+    }
+
+    /**
+     * Creates a new slot at the next possible slot in the GUI system.
+     * @see #newSlot(Integer)
      * @return a new (and tracked!) instance of GUISlot
      */
     public GUISlot newSlot() {
-        GUISlot newSlot = new GUISlot(this);
-        this.slots.add(newSlot);
-        return newSlot;
+        return this.newSlot(this.slots.size());
+    }
+
+    /**
+     * Gets the GUI slot at the inventory slot position.
+     * @param position the gui slot position, starting at 1.
+     * @return the gui slot object.
+     */
+    public GUISlot getSlot(Integer position) {
+        return this.slots.get(position);
+    }
+
+    /**
+     * Removes the {@link GUISlot} at the inventory slot position.
+     * @param position the gui slot position, starting at 1.
+     */
+    public void removeSlot(Integer position) {
+        this.slots.remove(position);
+    }
+
+    /**
+     * Update which slot of the GUI a {@link GUISlot} object shows in.
+     * @param position the gui slot position, starting at 1.
+     * @param slot the already created {@link GUISlot}  object to put in the slot.
+     */
+    public void setSlot(Integer position, GUISlot slot) {
+        this.slots.put(position, slot);
     }
 
     /**

--- a/src/main/java/playerquests/gui/GUIListener.java
+++ b/src/main/java/playerquests/gui/GUIListener.java
@@ -1,6 +1,5 @@
 package playerquests.gui;
 
-import org.bukkit.Bukkit; // used to broadcast messages to the server
 import org.bukkit.event.EventHandler; // used to register methods as events for the listener
 import org.bukkit.event.Listener; // listener type to implement this class with
 import org.bukkit.event.inventory.InventoryClickEvent; // called when player clicks in an inventory
@@ -42,7 +41,7 @@ public class GUIListener implements Listener {
     /**
      * Utility to check if the GUI is not null and
      * if the player is clicking the actual GUI itself.
-     * @return if in a GUI and clicking in the GUI (CHEST inventory) area.
+     * @return if in a GUI clicking in the GUI (CHEST inventory) area.
      */
     private Boolean isGUI(InventoryClickEvent event) {
         InventoryType inventoryType = event.getClickedInventory().getType();
@@ -55,6 +54,10 @@ public class GUIListener implements Listener {
             return false;
         }
     }
+
+    private Boolean isEmptySlot(Integer slotPosition) {
+        return this.gui.getSlot(slotPosition) == null;
+    }
     
     /**
      * When in a GUI this event is important for registering clicks
@@ -64,19 +67,12 @@ public class GUIListener implements Listener {
      */
     @EventHandler
     public void onClickItem(InventoryClickEvent event) {
-        
+        Integer slotPosition = event.getSlot() + 1; // get the real position of the slot
 
-        Bukkit.broadcastMessage("test");
-
-        if (this.isGUI(event)) { // if in a GUI and clicking in valid area.
-            Bukkit.broadcastMessage(String.valueOf(event.getClickedInventory().getType()));
-            Bukkit.broadcastMessage(String.valueOf(event.getSlot() + 1));
-            Bukkit.broadcastMessage(gui.getSlot(event.getSlot() + 1).getLabel());
-
+        if (this.isGUI(event) && !this.isEmptySlot(slotPosition)) { // if it's valid to register a GUI Slot click.
             event.setCancelled(true); // disallow taking slot items from GUI
 
-            //              we can either pass off the ItemStack clicked on with event.getCurrentItem()
-            // i prefer --> or the slot number that was clicked with event.getSlot()
+            gui.getSlot(slotPosition).execute(); // run the functions for this slot
         }
     }
 

--- a/src/main/java/playerquests/gui/GUIListener.java
+++ b/src/main/java/playerquests/gui/GUIListener.java
@@ -1,0 +1,67 @@
+package playerquests.gui;
+
+import org.bukkit.Bukkit; // used to broadcast messages to the server
+import org.bukkit.event.EventHandler; // used to register methods as events for the listener
+import org.bukkit.event.Listener; // listener type to implement this class with
+import org.bukkit.event.inventory.InventoryClickEvent; // called when player clicks in an inventory
+import org.bukkit.event.inventory.InventoryCloseEvent; // called when player closes an inventory
+
+/**
+ * Class used to hook special functionality onto regular 
+ * game events.
+ * <p>For example:
+ * <ul>
+ * <li>Inventory Click Events
+ * </ul>
+ */
+public class GUIListener implements Listener {
+
+    private GUI gui;
+
+    /**
+     * Constructs a new GUIListener.
+     * @param gui the gui window it should listen to events on.
+     */
+    public GUIListener(GUI gui) {
+        this.gui = gui;
+    }
+
+    /**
+     * Utility to check if the GUI is not null.
+     * @return whether there is a GUI open or not.
+     */
+    private Boolean isGUI() {
+        if (this.gui != null) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+    
+    /**
+     * When in a GUI this event is important for registering clicks
+     * and to stop items from being moved around like normal in an 
+     * inventory.
+     * @param event details about the inventory click event.
+     */
+    @EventHandler
+    public void onClickItem(InventoryClickEvent event) {
+        Bukkit.broadcastMessage("test");
+        if (this.isGUI()) {
+            event.setCancelled(true);
+        }
+    }
+
+    /**
+     * Handles what to do if the player closes the inventory window
+     * on their own without being closed from {@link GUI} class.
+     * @param event details about the inventory close event.
+     */
+    @EventHandler
+    public void onCloseGUI(InventoryCloseEvent event) {
+        if (this.isGUI()) {
+            this.gui.dispose(); // nullify some values in the GUI.
+            this.gui = null; // we don't want the class instance anymore (also probably helps garbage collector)
+        }
+    }
+}

--- a/src/main/java/playerquests/gui/GUIListener.java
+++ b/src/main/java/playerquests/gui/GUIListener.java
@@ -5,6 +5,7 @@ import org.bukkit.event.EventHandler; // used to register methods as events for 
 import org.bukkit.event.Listener; // listener type to implement this class with
 import org.bukkit.event.inventory.InventoryClickEvent; // called when player clicks in an inventory
 import org.bukkit.event.inventory.InventoryCloseEvent; // called when player closes an inventory
+import org.bukkit.event.inventory.InventoryType; // used to check if the clicked area is the GUI itself
 
 /**
  * Class used to hook special functionality onto regular 
@@ -37,6 +38,23 @@ public class GUIListener implements Listener {
             return false;
         }
     }
+
+    /**
+     * Utility to check if the GUI is not null and
+     * if the player is clicking the actual GUI itself.
+     * @return if in a GUI and clicking in the GUI (CHEST inventory) area.
+     */
+    private Boolean isGUI(InventoryClickEvent event) {
+        InventoryType inventoryType = event.getClickedInventory().getType();
+
+        // TODO: implement different inventory types; then compare to what the gui is set as instead of hardcoding as CHEST.
+
+        if (this.isGUI() && inventoryType == InventoryType.CHEST) { 
+            return true;
+        } else {
+            return false;
+        }
+    }
     
     /**
      * When in a GUI this event is important for registering clicks
@@ -46,9 +64,19 @@ public class GUIListener implements Listener {
      */
     @EventHandler
     public void onClickItem(InventoryClickEvent event) {
+        
+
         Bukkit.broadcastMessage("test");
-        if (this.isGUI()) {
-            event.setCancelled(true);
+
+        if (this.isGUI(event)) { // if in a GUI and clicking in valid area.
+            Bukkit.broadcastMessage(String.valueOf(event.getClickedInventory().getType()));
+            Bukkit.broadcastMessage(String.valueOf(event.getSlot() + 1));
+            Bukkit.broadcastMessage(gui.getSlot(event.getSlot() + 1).getLabel());
+
+            event.setCancelled(true); // disallow taking slot items from GUI
+
+            //              we can either pass off the ItemStack clicked on with event.getCurrentItem()
+            // i prefer --> or the slot number that was clicked with event.getSlot()
         }
     }
 

--- a/src/main/java/playerquests/gui/GUILoader.java
+++ b/src/main/java/playerquests/gui/GUILoader.java
@@ -151,6 +151,12 @@ public class GUILoader {
                 Optional.ofNullable(e.get("label")) // get label for slot if exists
                 .map(JsonNode::asText) // if exists get it as Text (String)
                 .ifPresent(label -> guiSlot.setLabel(label)); // set the GUI slot label
+
+                // parse functions, probably to:
+                // 1. guiSlot, then 
+                // 2. guiSlot when asked to execute functions delegates to wherever the function(s) lives.
+                // maybe for swiftly changing GUI screens as if it's one after the other, we can have an update function?
+                // maybe the functions can just be a meta version of the quest stage actions?
             }));
     }
 }

--- a/src/main/java/playerquests/gui/GUILoader.java
+++ b/src/main/java/playerquests/gui/GUILoader.java
@@ -142,7 +142,7 @@ public class GUILoader {
                 
                 Optional.ofNullable(e.get("slot")) // get slot field if it exists
                 .map(JsonNode::asInt) // if exists get it as Int (int)
-                .ifPresent(slot -> guiSlot.setSlot(slot)); // set the slot position in the GUI
+                .ifPresent(slot -> guiSlot.setPosition(slot)); // set the slot position in the GUI
 
                 Optional.ofNullable(e.get("item")) // get item to fill slot if exists
                 .map(JsonNode::asText) // if exists get it as Text (String)

--- a/src/main/java/playerquests/gui/GUISlot.java
+++ b/src/main/java/playerquests/gui/GUISlot.java
@@ -1,5 +1,9 @@
 package playerquests.gui;
 
+import java.util.ArrayList; // used to store a list of GUI Functions ('Meta Actions')
+import java.util.Optional; // used to do conditional actions if a param list is null
+
+import playerquests.gui.function.GUIFunction; // the class that handles Meta Actions
 import playerquests.utils.GUIUtils; // GUI related methods to make this class less verbose
 
 /**
@@ -10,23 +14,34 @@ import playerquests.utils.GUIUtils; // GUI related methods to make this class le
  */
 public class GUISlot {
 
-    private GUI gui; // the parent GUI
-    private int slot = 0; // no slot if none passed in // slot = this.gui.getNextSlot()?
+    private GUI parentGui; // the parent GUI
+    private int slot = 0; // no slot if none passed in // slot = this.parentGui.getNextSlot()?
     private String label = " "; // label of the item in the slot (requires whitespace to show as empty)
     private String item = "GRAY_STAINED_GLASS_PANE"; // default item/block
     private Boolean errored = false; // has this slot encountered a syntax error
+    private ArrayList<GUIFunction> functionList = new ArrayList<GUIFunction>(); // where the gui functions are added to and pulled from
 
     /**
      * Constructs a new {@link GUISlot} with the specified parent {@link GUI}.
      * <p>
      * This should not be accessed directly. Use {@link GUI#newSlot()} instead.
      * 
-     * @param gui a parent GUI which manages the window/screen.
+     * @param parentGui a parent GUI which manages the window/screen.
      * @param slotPosition where the slot should be in the GUI window, starting at 1.
      */
-    public GUISlot(GUI gui, Integer slotPosition) {
-        this.gui = gui;
+    public GUISlot(GUI parentGui, Integer slotPosition) {
+        this.parentGui = parentGui;
         this.setPosition(slotPosition);
+    }
+
+    /**
+     * Run the functions that are described in the GUI screen expression
+     */
+    public void execute() {
+        this.functionList.forEach(function -> {
+            function.setParentGUI(this.parentGui);
+            function.execute();
+        });
     }
 
     /**
@@ -36,11 +51,11 @@ public class GUISlot {
     public void setPosition(Integer position) {
         this.slot = position;
 
-        if (gui.getSlot(position) != null) { // remove slot if it already exists in HashMap
-            gui.removeSlot(position); // remove at slot position (hashmap key)
+        if (this.parentGui.getSlot(position) != null) { // remove slot if it already exists in HashMap
+            this.parentGui.removeSlot(position); // remove at slot position (hashmap key)
         }
 
-        gui.setSlot(position, this); // put our current GUISlot instead
+        this.parentGui.setSlot(position, this); // put our current GUISlot instead
     }
 
     /**
@@ -96,5 +111,17 @@ public class GUISlot {
      */
     public Boolean hasError() {
         return this.errored;
+    }
+
+    /**
+     * Add a GUI Function ('Meta Action') to be executed when this GUI Slot
+     * is used.
+     * @param guiFunction the Meta Action name.
+     * @param paramList the values for the Meta Action to use.
+     */
+    public void addFunction(GUIFunction guiFunction, ArrayList<Object> paramList) {
+        paramList = Optional.ofNullable(paramList).orElse(new ArrayList<Object>()); // if there is no paramList, create an empty one
+
+        this.functionList.add(guiFunction);
     }
 }

--- a/src/main/java/playerquests/gui/GUISlot.java
+++ b/src/main/java/playerquests/gui/GUISlot.java
@@ -1,6 +1,6 @@
 package playerquests.gui;
 
-import playerquests.utils.GUIUtils;
+import playerquests.utils.GUIUtils; // GUI related methods to make this class less verbose
 
 /**
  * The {@link GUISlot} class represents a slot in the inventory as GUI.
@@ -22,24 +22,32 @@ public class GUISlot {
      * This should not be accessed directly. Use {@link GUI#newSlot()} instead.
      * 
      * @param gui a parent GUI which manages the window/screen.
+     * @param slotPosition where the slot should be in the GUI window, starting at 1.
      */
-    public GUISlot(GUI gui) {
+    public GUISlot(GUI gui, Integer slotPosition) {
         this.gui = gui;
+        this.setPosition(slotPosition);
     }
 
     /**
      * Sets the slot position for this instance of {@link GUISlot}.
-     * @param slot the actual position of the slot, starting from 1
+     * @param position the actual position of the slot, starting from 1
      */
-    public void setSlot(Integer slot) {
-        this.slot = slot;
+    public void setPosition(Integer position) {
+        this.slot = position;
+
+        if (gui.getSlot(position) != null) { // remove slot if it already exists in HashMap
+            gui.removeSlot(position); // remove at slot position (hashmap key)
+        }
+
+        gui.setSlot(position, this); // put our current GUISlot instead
     }
 
     /**
      * Gets the intended slot position for this instance of {@link GUISlot}.
      * @return slot the slot position.
      */
-    public Integer getSlot() {
+    public Integer getPosition() {
         return this.slot;
     }
     

--- a/src/main/java/playerquests/gui/function/GUIFunction.java
+++ b/src/main/java/playerquests/gui/function/GUIFunction.java
@@ -1,0 +1,59 @@
+package playerquests.gui.function;
+
+import java.util.ArrayList; // used to store the params for this meta action
+import java.util.Objects; // used to require params be not null
+import java.util.stream.IntStream; // used to validate params are the correct types
+
+import playerquests.gui.GUI; // used to refer to the function and the slot parent GUI instance
+
+/**
+ * Passes and handles the GUI 'Functions' (otherwise known as 'Meta Actions') called by a GUI.
+ */
+public abstract class GUIFunction {
+
+    protected GUI parentGui;
+    protected ArrayList<Object> params;
+
+    /**
+     * Set the params for this function to use when it executes.
+     * @param params the expected params for the specific meta action.
+     */
+    public void setParams(ArrayList<Object> params) {
+        this.params = params;
+    }
+
+    /**
+     * Setting the GUI that the GUI Function belongs to.
+     * @param parentGui the GUI instance the player is seeing when they trigger the gui function/meta action.
+     */
+    public void setParentGUI(GUI parentGui) {
+        this.parentGui = parentGui;
+    }
+    
+    /**
+     * Method to be overridden by each meta action class.
+     */
+    public abstract void execute();
+
+    /**
+     * Essential utility which checks that the params suit this meta action. 
+     * @param params the values the meta action requires.
+     * @param expectedTypes the type of values the meta action requires.
+     */
+    public void validateParams(ArrayList<Object> params, Class<?>... expectedTypes) {
+        Objects.requireNonNull(params, "Params cannot be null");
+
+        // check if the size of the params list is the same as the size of the expectedTypes list
+        if (params.size() != expectedTypes.length) {
+            throw new IllegalArgumentException("Incorrect number of parameters");
+        }
+
+        // check with a filter if any param is not an instance of it's expected type
+        IntStream.range(0, params.size())
+        .filter(i -> !expectedTypes[i].isInstance(params.get(i)))
+        .findFirst()
+        .ifPresent(index -> {
+            throw new IllegalArgumentException("Parameter at index " + index + " does not match the expected type");
+        });
+    }
+}

--- a/src/main/java/playerquests/gui/function/Test.java
+++ b/src/main/java/playerquests/gui/function/Test.java
@@ -1,0 +1,19 @@
+package playerquests.gui.function;
+
+import org.bukkit.Bukkit; // used to broadcast a message if this meta action is used
+
+/**
+ * Just a simple tester class to validate if your GUI template/meta action is working.
+ */
+public class Test extends GUIFunction {
+
+    /**
+     * Sends a message in the console and chat to notify that this test executed.
+     */
+    @Override
+    public void execute() {
+        System.out.println("(the testing Meta Action was reached.)");
+        Bukkit.broadcastMessage("test function from GUI");
+    }
+    
+}

--- a/src/main/java/playerquests/gui/function/UpdateScreenFile.java
+++ b/src/main/java/playerquests/gui/function/UpdateScreenFile.java
@@ -1,0 +1,33 @@
+package playerquests.gui.function;
+
+import org.bukkit.entity.HumanEntity; // used to collect the viewer from the previous gui screen
+
+import playerquests.gui.GUI; // used to open a new GUI
+import playerquests.gui.GUILoader; // used to parse the GUI screen template
+
+/**
+ * Meta action to swiftly move to another GUI screen based on another template JSON file. 
+ */
+public class UpdateScreenFile extends GUIFunction {
+
+    /**
+     * Replaces an old GUI window with a new one as described by a template file.
+     */
+    @Override
+    public void execute() {
+        validateParams(this.params, String.class);
+
+        // collect information from old gui before closing it
+        HumanEntity previousViewer = this.parentGui.getViewer();
+
+        this.parentGui.close(); // move on from the existing GUI so we can swap to a new one
+
+        // collect params
+        String fileName = (String) params.get(0);
+
+        // open the new GUI
+        GUILoader guiLoader = new GUILoader(previousViewer);
+        GUI gui = guiLoader.load(fileName);
+        gui.open();
+    }
+}

--- a/src/main/java/playerquests/quest/Quest.java
+++ b/src/main/java/playerquests/quest/Quest.java
@@ -8,8 +8,8 @@ import playerquests.gui.GUILoader;
 public class Quest {
     
     public static void display(HumanEntity humanEntity) {
-        GUILoader guiLoader = new GUILoader(humanEntity);
-        GUI gui = guiLoader.load("empty");
-        gui.open();
+        GUILoader guiLoader = new GUILoader(humanEntity); // create tool to build guis with
+        GUI gui = guiLoader.load("main"); // build/load the gui with a template file
+        gui.open(); // prepare and open the GUI on the player screen
     }
 }

--- a/src/main/java/playerquests/quest/Quest.java
+++ b/src/main/java/playerquests/quest/Quest.java
@@ -1,12 +1,26 @@
 package playerquests.quest;
 
-import org.bukkit.entity.HumanEntity;
+import org.bukkit.entity.HumanEntity; // the player to show the GUI to
 
-import playerquests.gui.GUI;
-import playerquests.gui.GUILoader;
+import playerquests.gui.GUI; // the main class for the gui
+import playerquests.gui.GUILoader; // the means to load a gui template from JSON
 
+/**
+ * The main class for Quest functionality / the Quest engine.
+ */
 public class Quest {
+
+    /**
+     * Quest should not be instantiated.
+     */
+    private Quest() {
+        throw new AssertionError("Quest class should not be instantiated.");
+    }
     
+    /**
+     * Open the main GUI on the player screen.
+     * @param humanEntity the player who should receive/see the GUI.
+     */
     public static void display(HumanEntity humanEntity) {
         GUILoader guiLoader = new GUILoader(humanEntity); // create tool to build guis with
         GUI gui = guiLoader.load("main"); // build/load the gui with a template file

--- a/src/main/java/playerquests/utils/GUIUtils.java
+++ b/src/main/java/playerquests/utils/GUIUtils.java
@@ -9,6 +9,13 @@ import org.bukkit.inventory.ItemStack;
 public class GUIUtils {
 
     /**
+     * GUIUtils should not be instantiated.
+     */
+    private GUIUtils() {
+        throw new AssertionError("GUIUtils should not be instantiated.");
+    }
+
+    /**
      * Converts a {@link String} to an {@link ItemStack}.
      * @param item closest string to the {@link Material} ENUM
      * @return itemStack an instance of an {@link ItemStack} with the matching item 

--- a/src/main/java/playerquests/utils/GUIUtils.java
+++ b/src/main/java/playerquests/utils/GUIUtils.java
@@ -1,7 +1,7 @@
 package playerquests.utils;
 
-import org.bukkit.Material;
-import org.bukkit.inventory.ItemStack;
+import org.bukkit.Material; // used to get a usable material instance
+import org.bukkit.inventory.ItemStack; // important type used to fill GUI slots
 
 /**
  * Helpful tools which can reduce the verbosity of GUI classes.

--- a/src/main/resources/gui/screens/create-quest.json
+++ b/src/main/resources/gui/screens/create-quest.json
@@ -1,0 +1,4 @@
+{
+    "title": "Create Quest",
+    "size": 9
+}

--- a/src/main/resources/gui/screens/demo.json
+++ b/src/main/resources/gui/screens/demo.json
@@ -9,6 +9,9 @@
             "functions": [
                 { "name": "test", "params": ["hi"] },
                 { "name": "testDemo", "params": ["hi"] }
+            ],
+            "actions": [
+                { "name": "Example", "params": [] }
             ]
         },
         {

--- a/src/main/resources/gui/screens/demo.json
+++ b/src/main/resources/gui/screens/demo.json
@@ -7,8 +7,8 @@
             "item": "SADDLE",
             "label": "Test",
             "functions": [
-                { "name": "test", "params": ["hi"] },
-                { "name": "testDemo", "params": ["hi"] }
+                { "name": "Test", "params": ["hi"] },
+                { "name": "UpdateScreenFile", "params": ["hi"] }
             ],
             "actions": [
                 { "name": "Example", "params": [] }
@@ -17,8 +17,11 @@
         {
             "slot": 18,
             "item": "WOOL",
-            "label": "Second Test"
+            "label": "Second Test",
+            "functions": [
+                { "name": "Test", "params": [] }
+            ]
         },
         {}
     ]
-  }
+}

--- a/src/main/resources/gui/screens/main.json
+++ b/src/main/resources/gui/screens/main.json
@@ -5,7 +5,13 @@
         {
             "slot": 2,
             "item": "LIME_DYE",
-            "label": "Create Quest"
+            "label": "Create Quest",
+            "functions": [
+                { "name": "metaUpdateScreenFile", "params": ["create-quest"] }
+            ],
+            "actions": [
+                { "name": "Normies", "params": [] }
+            ]
         }
     ]
   }

--- a/src/main/resources/gui/screens/main.json
+++ b/src/main/resources/gui/screens/main.json
@@ -1,0 +1,11 @@
+{
+    "title": "PlayerQuests",
+    "size": 9,
+    "slots": [
+        {
+            "slot": 2,
+            "item": "LIME_DYE",
+            "label": "Create Quest"
+        }
+    ]
+  }

--- a/src/main/resources/gui/screens/main.json
+++ b/src/main/resources/gui/screens/main.json
@@ -7,11 +7,11 @@
             "item": "LIME_DYE",
             "label": "Create Quest",
             "functions": [
-                { "name": "metaUpdateScreenFile", "params": ["create-quest"] }
+                { "name": "UpdateScreenFile", "params": ["create-quest"] }
             ],
             "actions": [
                 { "name": "Normies", "params": [] }
             ]
         }
     ]
-  }
+}

--- a/src/test/java/playerquests/gui/GUITest.java
+++ b/src/test/java/playerquests/gui/GUITest.java
@@ -1,8 +1,11 @@
 package playerquests.gui;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
 
+import org.bukkit.Bukkit;
 import org.bukkit.entity.HumanEntity;
+import org.bukkit.plugin.PluginManager;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -16,6 +19,10 @@ public class GUITest extends BukkitTestUtil {
 
     @BeforeAll
     void setUp() {
+        // creating mock Bukkit and getPluginManager for the GUI initializer
+        PluginManager pluginManager = Mockito.mock(PluginManager.class);
+        when(Bukkit.getPluginManager()).thenReturn(pluginManager);
+
         // creating mock humanEntity to start a GUI
         this.humanEntity = Mockito.mock(HumanEntity.class);
 

--- a/src/test/java/playerquests/gui/GUITest.java
+++ b/src/test/java/playerquests/gui/GUITest.java
@@ -30,15 +30,16 @@ public class GUITest extends BukkitTestUtil {
         this.guiLoader = new GUILoader(humanEntity);
     }
 
-    @Test 
+    @Test
     void validTemplate() {
-        // valid templateFile, should be found in resources
+        // Load the GUI with the resource named "demo"
         GUI gui = this.guiLoader.load("demo");
-
+            
+        // Perform assertions on the loaded GUI
         assertEquals("Demo", gui.getTitle());
         assertEquals(18, gui.getSize());
     }
-
+    
     @Test
     void emptyTemplate() {
         // invalid templateFile, an empty json object


### PR DESCRIPTION
# Create Quest button + GUI screen changing
When pressing Create Quest it will now take you to a new screen: [added create quest to main GUI](https://github.com/sammypanda/MCJE-PlayerQuests-Plugin/commit/57456470f461a5868af9a89cb6a26c8795d99e21). This is flexible behaviour and can now be done for any screen going to any other screen just by using the templates.

Templates (minimal versions):
```
main.json
{
    "title": "PlayerQuests",
    "size": 9,
    "slots": [
        {
            "slot": 2,
            "item": "LIME_DYE",
            "label": "Create Quest",
            "functions": [
                { "name": "UpdateScreenFile", "params": ["create-quest"] }
            ]
        }
    ]
}
```

```
create-quest.json
{
    "title": "Create Quest",
    "size": 9
}
```

[Swapping from main.json to create-quest.json templates, shown in-game](https://github.com/sammypanda/MCJE-PlayerQuests-Plugin/assets/38725335/80aa8f03-0459-4c07-baf9-df21a8f8faa6)
