### PR TITLE
Use quest caching instead of real-time database (and other QOL fixes)

### DIFF
--- a/branding/docs/developers/README.md
+++ b/branding/docs/developers/README.md
@@ -28,11 +28,11 @@ TODO: Each <ins>quest</ins> is a <ins>container of stages</ins>. Each <ins>stage
 
 # How To Get Functionality: 'Templates'
 ###### We have Meta and Quest Actions, but how do we actually use them?
-TODO: Usually you would never need this, but this is what makes it all tick. When you create a Quest: stages, npcs, actions and all; this is the format and layout it is constructing:
+Usually you would never need this, but this is what makes it all tick. When you create a Quest: stages, npcs, actions and all; this is the format and layout it is constructing:
 ```json
 {
     "title": String, // label of the entire quest
-    "entry": String, // (as in 'entry point') where the quest starts
+    "entry": String, // Path: (as in 'entry point') where the quest starts
     "creator": UUID, // the player who created this quest
     "id": String, // the id, composed of: [Quest Title]_[Creator UUID]
     "npcs": { // directory of all the quest npcs
@@ -55,7 +55,7 @@ TODO: Usually you would never need this, but this is what makes it all tick. Whe
         "stage_0": { // Stage ID (automatically generated)
             "notable": Boolean, // if it would show up as a chapter in a book; a notable stage
             "label": String, // the label for just this stage, as if it were a chapter
-            "entry": String, // where the stage starts
+            "entry": String, // Path: where the stage starts
             "actions": { // directory of all this stage's actions
                 "action_0": {  // Action ID (automatically generated)
                     "type": String, // Quest Action type
@@ -70,15 +70,16 @@ TODO: Usually you would never need this, but this is what makes it all tick. Whe
                 }
             },
             "connections": { // defining where the stage is in the quest
-                "next": @Nullable String, // where to go if the stage succeeds
-                "curr": @Nullable String, // where to return to if the stage is exited
-                "prev": @Nullable String // where to go if the stage fails
+                "next": @Nullable String, // Path: where to go if the stage succeeds
+                "curr": @Nullable String, // Path: where to return to if the stage is exited
+                "prev": @Nullable String // Path: where to go if the stage fails
             }
         },
     }
 }
 ```
-*It's worth noting that just because the IDs are incremental, all starting from zero, doesn't mean they are expected to be kept/used in order or in sequence.*
+- *It's worth noting that just because the IDs are incremental, all starting from zero, doesn't mean they are expected to be kept/used in order or in sequence.*
+- *'Path:' means the string is represented something like: "stage_0.action_0", it can also be just like: "stage_0"*
 
 # How It All Works: 'Specification'
 ###### the way to visualise/think about, and implement the program.

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>moe.sammypanda</groupId>
   <artifactId>playerquests</artifactId>
-  <version>0.5</version>
+  <version>0.5.1</version>
 
   <packaging>jar</packaging>
 

--- a/src/main/java/playerquests/Core.java
+++ b/src/main/java/playerquests/Core.java
@@ -39,6 +39,7 @@ public class Core extends JavaPlugin {
     /**
      * Core class, to be instantiated by server.
      */
+    // TODO: always talk to database through a class (for caching and real-time data). Never talk directly! (It can't handle it).
     public Core() {}
 
     @Override

--- a/src/main/java/playerquests/Core.java
+++ b/src/main/java/playerquests/Core.java
@@ -55,6 +55,11 @@ public class Core extends JavaPlugin {
         new Metrics(this, 22692);
     }
 
+    @Override
+    public void onDisable() {
+        PlayerQuests.getServerListener().onDisable();
+    }
+
     /**
      * Mechanism to make the Plugin accessible for other classes.
      * @return the main plugin instance

--- a/src/main/java/playerquests/builder/gui/dynamic/Dynamicactioneditor.java
+++ b/src/main/java/playerquests/builder/gui/dynamic/Dynamicactioneditor.java
@@ -13,6 +13,7 @@ import playerquests.builder.gui.function.ChatPrompt; // prompts the user for inp
 import playerquests.builder.gui.function.UpdateScreen; // going to previous screen
 import playerquests.builder.quest.action.QuestAction; // describes a quest action
 import playerquests.builder.quest.data.ActionOption; // a setting that can be set for an action
+import playerquests.builder.quest.data.StagePath;
 import playerquests.builder.quest.npc.QuestNPC; // describes a quest NPC
 import playerquests.builder.quest.stage.QuestStage; // describes a quest stage
 import playerquests.client.ClientDirector; // controlling the plugin
@@ -58,7 +59,7 @@ public class Dynamicactioneditor extends GUIDynamic {
         this.putOptionSlots(Arrays.asList(1,2,3,10,11,12));
 
         // set label
-        if (this.stage.getEntryPoint().getID() == this.action.getID()) { // if this action is the entry point
+        if (this.stage.getEntryPoint().getAction() == this.action.getID()) { // if this action is the entry point
             this.gui.getFrame().setTitle(this.action + " Editor (Entry Point)");
         } else {
             this.gui.getFrame().setTitle(this.action + " Editor");
@@ -108,7 +109,7 @@ public class Dynamicactioneditor extends GUIDynamic {
             .setLabel("Delete Action")
             .setItem("RED_DYE")
             .onClick(() -> {
-                if (stage.getEntryPoint().equals(action)) {
+                if (stage.getEntryPoint().getAction(stage.getQuest()).equals(action)) {
                     ChatUtils.message("Cannot remove the stage starting point action.")
                         .player(this.director.getPlayer())
                         .type(MessageType.WARN)
@@ -140,7 +141,7 @@ public class Dynamicactioneditor extends GUIDynamic {
         entrypointButton.setItem("ENDER_EYE");
         entrypointButton.setLabel("Set Action As Entry Point");
         entrypointButton.onClick(() -> {
-            this.stage.setEntryPoint(this.action.getID()); // set this action as the stage entry point
+            this.stage.setEntryPoint(new StagePath(this.stage, this.action)); // set this action as the stage entry point
             this.execute(); // re-run to see changes
         });
 

--- a/src/main/java/playerquests/builder/gui/dynamic/Dynamicconnectioneditor.java
+++ b/src/main/java/playerquests/builder/gui/dynamic/Dynamicconnectioneditor.java
@@ -6,6 +6,7 @@ import java.util.Arrays;
 import playerquests.builder.gui.component.GUISlot;
 import playerquests.builder.gui.function.UpdateScreen;
 import playerquests.builder.quest.data.ConnectionsData;
+import playerquests.builder.quest.data.StagePath;
 import playerquests.client.ClientDirector;
 
 public class Dynamicconnectioneditor extends GUIDynamic {
@@ -26,9 +27,9 @@ public class Dynamicconnectioneditor extends GUIDynamic {
 
     @Override
     protected void execute_custom() {
-        String prev = this.connections.getPrev();
-        String curr = this.connections.getCurr();
-        String next = this.connections.getNext();
+        StagePath prev = this.connections.getPrev();
+        StagePath curr = this.connections.getCurr();
+        StagePath next = this.connections.getNext();
 
         this.gui.getFrame().setTitle("Sequence Editor");
 
@@ -88,7 +89,7 @@ public class Dynamicconnectioneditor extends GUIDynamic {
             Dynamicselectconnection connectionSelector = (Dynamicselectconnection) functionUpdateScreen.getDynamicGUI();
 
             connectionSelector.onSelect((selectionObject) -> {
-                String selection = selectionObject.toString();
+                StagePath selection = (StagePath) selectionObject;
 
                 switch (connection) {
                     case "prev":

--- a/src/main/java/playerquests/builder/gui/dynamic/Dynamicmyquest.java
+++ b/src/main/java/playerquests/builder/gui/dynamic/Dynamicmyquest.java
@@ -6,6 +6,7 @@ import java.util.Arrays; // generic arrays type
 import playerquests.builder.gui.component.GUIFrame; // the outer frame of the GUI window
 import playerquests.builder.gui.component.GUISlot; // inventory slots representing GUI buttons
 import playerquests.builder.gui.function.UpdateScreen; // GUI function to change GUI
+import playerquests.builder.quest.QuestBuilder; // instantiating a builder for the quest (for editing an existing quest)
 import playerquests.client.ClientDirector; // how a player client interacts with the plugin
 import playerquests.product.Quest; // complete quest objects
 import playerquests.utility.singleton.QuestRegistry; // tracking quests/questers
@@ -60,10 +61,16 @@ public class Dynamicmyquest extends GUIDynamic {
         new GUISlot(gui, 3)
             .setItem("WRITABLE_BOOK")
             .setLabel("Edit")
-            .addFunction(new UpdateScreen(
-                new ArrayList<>(Arrays.asList("questeditor")), 
-                director
-            ));
+            .onClick(() -> {
+                // create a quest builder (for editing)
+                director.setCurrentInstance(new QuestBuilder(director, this.quest));
+
+                // open the editor
+                new UpdateScreen(
+                    new ArrayList<>(Arrays.asList("questeditor")), 
+                    director
+                ).execute();
+            });
 
         // create remove quest button (with confirmation check)
         if (confirm_delete.equals(false)) {

--- a/src/main/java/playerquests/builder/gui/dynamic/Dynamicmyquest.java
+++ b/src/main/java/playerquests/builder/gui/dynamic/Dynamicmyquest.java
@@ -6,17 +6,11 @@ import java.util.Arrays; // generic arrays type
 import playerquests.builder.gui.component.GUIFrame; // the outer frame of the GUI window
 import playerquests.builder.gui.component.GUISlot; // inventory slots representing GUI buttons
 import playerquests.builder.gui.function.UpdateScreen; // GUI function to change GUI
-import playerquests.builder.quest.QuestBuilder; // for quest management
 import playerquests.client.ClientDirector; // how a player client interacts with the plugin
 import playerquests.product.Quest; // complete quest objects
 import playerquests.utility.singleton.QuestRegistry; // tracking quests/questers
 
 public class Dynamicmyquest extends GUIDynamic {
-
-    /**
-     * The current quest
-     */
-    QuestBuilder questBuilder;
 
     /**
      * The quest product
@@ -35,8 +29,7 @@ public class Dynamicmyquest extends GUIDynamic {
     @Override
     protected void setUp_custom() {
         // retrieve the current quest from the client director
-        this.questBuilder = (QuestBuilder) this.director.getCurrentInstance(QuestBuilder.class);
-        this.quest = questBuilder.build();
+        this.quest = (Quest) this.director.getCurrentInstance(Quest.class);
     }
 
     @Override
@@ -44,7 +37,7 @@ public class Dynamicmyquest extends GUIDynamic {
         GUIFrame guiFrame = this.gui.getFrame();
 
         // set the GUI window title
-        String questTitle = this.questBuilder.getTitle();
+        String questTitle = this.quest.getTitle();
         Integer questTitleLimit = 12;
         guiFrame.setTitle(
             String.format(
@@ -87,7 +80,7 @@ public class Dynamicmyquest extends GUIDynamic {
                 .setLabel("Delete (Confirm)")
                 .onClick(() -> {
                     // delete the quest
-                    Boolean deleted = QuestRegistry.getInstance().delete(questBuilder.build());
+                    Boolean deleted = QuestRegistry.getInstance().delete(quest);
 
                     // go back if successful
                     if (deleted) {

--- a/src/main/java/playerquests/builder/gui/dynamic/Dynamicmyquest.java
+++ b/src/main/java/playerquests/builder/gui/dynamic/Dynamicmyquest.java
@@ -100,22 +100,15 @@ public class Dynamicmyquest extends GUIDynamic {
         }
 
         // create quest toggle button
-        // to toggle on
-        GUISlot toggleButton = new GUISlot(gui, 9)
-            .setItem("GRAY_STAINED_GLASS_PANE")
-            .setLabel("Toggle On");
-
-        if (quest.isToggled()) {
-            // to toggle off
-            toggleButton
-                .setItem("GREEN_STAINED_GLASS_PANE")
-                .setLabel("Toggle Off");
-        }
-
-        toggleButton.onClick(() -> {
-            quest.toggle();
-            this.execute(); // refresh UI
-        });
+        Boolean isToggled = quest.isToggled();
+        
+        new GUISlot(gui, 9)
+            .setItem(isToggled ? "GREEN_STAINED_GLASS_PANE" : "GRAY_STAINED_GLASS_PANE")
+            .setLabel(isToggled ? "Toggle Off" : "Toggle On")
+            .onClick(() -> {
+                quest.toggle();
+                this.execute(); // refresh UI
+            });
     }
     
 }

--- a/src/main/java/playerquests/builder/gui/dynamic/Dynamicmyquests.java
+++ b/src/main/java/playerquests/builder/gui/dynamic/Dynamicmyquests.java
@@ -1,6 +1,5 @@
 package playerquests.builder.gui.dynamic;
 
-import java.io.File; // retrieve the template files
 import java.util.ArrayList; // stores the quests this player owns
 import java.util.Arrays; // working with literal arrays
 import java.util.concurrent.CompletableFuture; // async methods
@@ -8,8 +7,6 @@ import java.util.stream.Collectors; // used to turn a stream to a list
 import java.util.stream.IntStream; // fills slots procedually
 
 import org.bukkit.Bukkit;
-import org.bukkit.event.server.ServerLoadEvent; // emulating server load event
-import org.bukkit.event.server.ServerLoadEvent.LoadType; // param for ^
 
 import playerquests.Core; // fetching Singletons (like: Plugin)
 import playerquests.builder.gui.component.GUISlot; // creating each quest button / other buttons
@@ -17,10 +14,7 @@ import playerquests.builder.gui.function.UpdateScreen;// used to go back to the 
 import playerquests.builder.quest.QuestBuilder; // the class which constructs a quest product
 import playerquests.client.ClientDirector; // for controlling the plugin
 import playerquests.product.Quest; // a quest product used to play and track quests
-import playerquests.utility.ChatUtils;
-import playerquests.utility.ChatUtils.MessageType;
 import playerquests.utility.singleton.Database;
-import playerquests.utility.singleton.PlayerQuests; // used to get plugin listeners
 import playerquests.utility.singleton.QuestRegistry; // centralised hub backend for quests/questers
 
 /**
@@ -54,11 +48,6 @@ public class Dynamicmyquests extends GUIDynamic {
     private Integer invalidQuests = 0;
 
     /**
-     * get the list of all quest templates with owner: null or owner: player UUID
-     */
-    private File questTemplatesDir = new File(Core.getPlugin().getDataFolder(), "/quest/templates");
-
-    /**
      * indicate when the quests can start to load in
      */
     private Boolean myquestLoaded = false;
@@ -84,20 +73,6 @@ public class Dynamicmyquests extends GUIDynamic {
      * </ul>
      */
     public void setUp_custom() {
-        // correct for missing templates directory
-        if (!this.questTemplatesDir.exists()) {
-            PlayerQuests.getServerListener().onLoad(new ServerLoadEvent(LoadType.RELOAD)).onFinish(() -> {
-                // imitate reload to retry plugin set-up
-                this.setUp_custom();
-            });
-            ChatUtils.message("Setting up for the first time")
-                .type(MessageType.NOTIF)
-                .player(this.director.getPlayer())
-                .send();
-                
-            return;
-        }
-
         // get list of quest templates
         if (!this.myquestLoaded) {
             CompletableFuture.runAsync(() -> {

--- a/src/main/java/playerquests/builder/gui/dynamic/Dynamicmyquests.java
+++ b/src/main/java/playerquests/builder/gui/dynamic/Dynamicmyquests.java
@@ -14,7 +14,6 @@ import playerquests.builder.gui.function.UpdateScreen;// used to go back to the 
 import playerquests.builder.quest.QuestBuilder; // the class which constructs a quest product
 import playerquests.client.ClientDirector; // for controlling the plugin
 import playerquests.product.Quest; // a quest product used to play and track quests
-import playerquests.utility.singleton.Database;
 import playerquests.utility.singleton.QuestRegistry; // centralised hub backend for quests/questers
 
 /**
@@ -77,7 +76,7 @@ public class Dynamicmyquests extends GUIDynamic {
         if (!this.myquestLoaded) {
             CompletableFuture.runAsync(() -> {
                 // get quests from database
-                this.myquestTemplates.addAll(Database.getInstance().getAllQuests());
+                this.myquestTemplates.addAll(Core.getQuestRegistry().getAllQuests().keySet());
 
             // do when quests have been gotten
             }).thenRun(() -> {

--- a/src/main/java/playerquests/builder/gui/dynamic/Dynamicmyquests.java
+++ b/src/main/java/playerquests/builder/gui/dynamic/Dynamicmyquests.java
@@ -2,6 +2,8 @@ package playerquests.builder.gui.dynamic;
 
 import java.util.ArrayList; // stores the quests this player owns
 import java.util.Arrays; // working with literal arrays
+import java.util.LinkedHashSet; // hash set, but with order :D
+import java.util.Set;
 import java.util.concurrent.CompletableFuture; // async methods
 import java.util.stream.Collectors; // used to turn a stream to a list
 import java.util.stream.IntStream; // fills slots procedually
@@ -29,7 +31,7 @@ public class Dynamicmyquests extends GUIDynamic {
     /**
      * The quest templates belonging to no-one or this player
      */
-    private ArrayList<String> myquestTemplates = new ArrayList<>();
+    private Set<String> myquestTemplates = new LinkedHashSet<>();
 
     /**
      * the position of the last slot put on a page
@@ -85,6 +87,7 @@ public class Dynamicmyquests extends GUIDynamic {
                 // return to the main thread
                 Bukkit.getScheduler().runTask(Core.getPlugin(), () -> {
                     // refresh the screen/remove the 'load'/show the quests; continue
+                    this.gui.clearSlots(); // fresh!
                     this.execute();
                 });
                 
@@ -132,7 +135,7 @@ public class Dynamicmyquests extends GUIDynamic {
             // filter out the templates (pagination)
             ArrayList<String> remainingTemplates = (ArrayList<String>) this.myquestTemplates
                 .stream()
-                .filter(i -> this.myquestTemplates.indexOf(i) > this.lastBuiltSlot - 1)
+                .filter(i -> new ArrayList<String>(this.myquestTemplates).indexOf(i) > this.lastBuiltSlot - 1)
                 .collect(Collectors.toList());
 
             // generate the paginated slots
@@ -145,7 +148,6 @@ public class Dynamicmyquests extends GUIDynamic {
      * @param remainingTemplates the quest templates to insert
      */
     private void generatePage(ArrayList<String> remainingTemplates) {
-
         // when the exit button is pressed
         GUISlot exitButton = new GUISlot(this.gui, 37);
         exitButton.setLabel("Back");

--- a/src/main/java/playerquests/builder/gui/dynamic/Dynamicmyquests.java
+++ b/src/main/java/playerquests/builder/gui/dynamic/Dynamicmyquests.java
@@ -46,7 +46,7 @@ public class Dynamicmyquests extends GUIDynamic {
     /**
      * maximum auto-generated slots per page
      */
-    private Integer slotsPerPage = 35;
+    private Integer slotsPerPage = 36;
 
     /**
      * count of malformed quests

--- a/src/main/java/playerquests/builder/gui/dynamic/Dynamicquesteditor.java
+++ b/src/main/java/playerquests/builder/gui/dynamic/Dynamicquesteditor.java
@@ -6,7 +6,7 @@ import java.util.Arrays; // generic array handling
 import playerquests.builder.gui.component.GUIFrame; // describes the outer GUI frame/window
 import playerquests.builder.gui.component.GUISlot; // describes a GUI button
 import playerquests.builder.gui.function.ChatPrompt; // GUI taking input from chat box
-import playerquests.builder.gui.function.Save; // saves data via GUI button
+import playerquests.builder.gui.function.Save;
 import playerquests.builder.gui.function.UpdateScreen; // changing the GUI screen to another
 import playerquests.builder.quest.QuestBuilder; // controlling a quest
 import playerquests.client.ClientDirector; // accessing the client state

--- a/src/main/java/playerquests/builder/gui/dynamic/Dynamicquesteditor.java
+++ b/src/main/java/playerquests/builder/gui/dynamic/Dynamicquesteditor.java
@@ -9,6 +9,7 @@ import playerquests.builder.gui.function.ChatPrompt; // GUI taking input from ch
 import playerquests.builder.gui.function.Save;
 import playerquests.builder.gui.function.UpdateScreen; // changing the GUI screen to another
 import playerquests.builder.quest.QuestBuilder; // controlling a quest
+import playerquests.builder.quest.data.StagePath;
 import playerquests.client.ClientDirector; // accessing the client state
 
 /**
@@ -104,11 +105,9 @@ public class Dynamicquesteditor extends GUIDynamic {
                     Dynamicselectconnection selector = (Dynamicselectconnection) function.getDynamicGUI();
 
                     selector.onSelect((selected) -> {
-                        questBuilder.setEntryPoint(selector.selectedStage);
-
-                        if (selector.selectedAction != null) {
-                            selector.selectedStage.setEntryPoint(selector.selectedAction.getID());
-                        }
+                        // get the chosen entry point (as a stage path 'stage_[num].action_[num]' for precision)
+                        StagePath path = (StagePath) selected;
+                        questBuilder.setEntryPoint(new StagePath(path.getStage(), path.getAction()));
                     });
                 }).execute();
             });

--- a/src/main/java/playerquests/builder/gui/dynamic/Dynamicquestnpcs.java
+++ b/src/main/java/playerquests/builder/gui/dynamic/Dynamicquestnpcs.java
@@ -99,6 +99,7 @@ public class Dynamicquestnpcs extends GUIDynamic {
         addButton.setLabel("Add NPC");
         addButton.onClick(() -> {
             QuestNPC npc = new QuestNPC(); // create new empty npc
+            npc.setQuest(questBuilder.build());
             this.director.setCurrentInstance(npc);
 
             new UpdateScreen(

--- a/src/main/java/playerquests/builder/gui/dynamic/Dynamicqueststage.java
+++ b/src/main/java/playerquests/builder/gui/dynamic/Dynamicqueststage.java
@@ -107,7 +107,7 @@ public class Dynamicqueststage extends GUIDynamic {
                 GUISlot actionSlot = new GUISlot(this.gui, nextEmptySlot);
 
                 // identify which action is the stage entry point
-                if (this.questStage.getEntryPoint().getID().equals(action)) { // if this action is the entry point
+                if (this.questStage.getEntryPoint().getAction().equals(action)) { // if this action is the entry point
                     actionSlot.setLabel(action.toString() + " (Entry Point)");
                     actionSlot.setItem("POWERED_RAIL");
                 } else { // if it's not the entry point

--- a/src/main/java/playerquests/builder/gui/dynamic/Dynamicqueststage.java
+++ b/src/main/java/playerquests/builder/gui/dynamic/Dynamicqueststage.java
@@ -170,14 +170,20 @@ public class Dynamicqueststage extends GUIDynamic {
 
         // add 'new action' button
         GUISlot newActionButton = new GUISlot(this.gui, this.gui.getFrame().getSize());
-        newActionButton.setLabel("Add Action");
-        newActionButton.setItem("LIME_DYE");
-        newActionButton.onClick(() -> {
-            new None(this.questStage).submit(); // create the new action
-            this.confirm_actionKeys = false; // set actionKeys to be looped through again
-            this.gui.clearSlots();
-            this.execute(); // re-run to see new action in list
-        });
+        
+        if (this.questStage.getActions().size() < 12) {
+            newActionButton.setLabel("Add Action");
+            newActionButton.setItem("LIME_DYE");
+            newActionButton.onClick(() -> {
+                new None(this.questStage).submit(); // create the new action
+                this.confirm_actionKeys = false; // set actionKeys to be looped through again
+                this.gui.clearSlots();
+                this.execute(); // re-run to see new action in list
+            });
+        } else {
+            newActionButton.setLabel("No More Action Slots");
+            newActionButton.setItem("BARRIER");
+        }
     }
     
 }

--- a/src/main/java/playerquests/builder/gui/dynamic/Dynamicqueststages.java
+++ b/src/main/java/playerquests/builder/gui/dynamic/Dynamicqueststages.java
@@ -59,10 +59,14 @@ public class Dynamicqueststages extends GUIDynamic {
         this.gui.getFrame().setTitle(this.guiTitle); // set the GUI title
         this.gui.getFrame().setSize( // set number of slots in the GUI
             Math.min( // get up to 54 (maximum slots)
-                (this.questBuilder.getStages().size() + 9) / 9 * 9, // only multiples of 9
+                (this.questBuilder.getStages().size() + 20) / 9 * 9, // only multiples of 9
                 54 // 54 maximum slots
             )
         );
+
+        // restart inv in-case GUI size is changed
+        this.gui.getResult().minimise();
+        this.gui.getResult().open();
 
         // dividers (first two rows)
         IntStream.iterate(1, n -> n + 9).limit(54/9).forEach((divSlot) -> {
@@ -83,21 +87,22 @@ public class Dynamicqueststages extends GUIDynamic {
         ));
 
         // add new stage button
-        new GUISlot(this.gui, this.gui.getFrame().getSize())
-            .setLabel("Add Stage")
-            .setItem("LIME_DYE")
-            .onClick(() -> {
-                questBuilder.addStage(
-                    new QuestStage(
-                        this.questBuilder.build(), 
-                        this.questBuilder.getStages().isEmpty() ? 0 : Integer.parseInt(this.questBuilder.getStages().getLast().substring(6)) + 1
-                    )
-                );
+        if (this.questBuilder.getStages().size() < 42) {
+            new GUISlot(this.gui, this.gui.getFrame().getSize())
+                .setLabel("Add Stage")
+                .setItem("LIME_DYE")
+                .onClick(() -> {
+                    questBuilder.addStage(
+                        new QuestStage(
+                            this.questBuilder.build(), 
+                            this.questBuilder.getStages().isEmpty() ? 0 : Integer.parseInt(this.questBuilder.getStages().getLast().substring(6)) + 1
+                        )
+                    );
 
-                this.gui.clearSlots();
-
-                this.execute(); // rebuild GUI
-            });
+                    this.gui.clearSlots();
+                    this.execute(); // rebuild GUI
+                });
+        }
 
         IntStream.range(0, this.questBuilder.getStages().size()).anyMatch(index -> {
 

--- a/src/main/java/playerquests/builder/gui/dynamic/Dynamicqueststages.java
+++ b/src/main/java/playerquests/builder/gui/dynamic/Dynamicqueststages.java
@@ -90,7 +90,7 @@ public class Dynamicqueststages extends GUIDynamic {
                 questBuilder.addStage(
                     new QuestStage(
                         this.questBuilder.build(), 
-                        this.questBuilder.getStages().isEmpty() ? 0 : Integer.parseInt(this.questBuilder.getStages().getLast().substring(6) + 1)
+                        this.questBuilder.getStages().isEmpty() ? 0 : Integer.parseInt(this.questBuilder.getStages().getLast().substring(6)) + 1
                     )
                 );
 

--- a/src/main/java/playerquests/builder/gui/dynamic/Dynamicselectconnection.java
+++ b/src/main/java/playerquests/builder/gui/dynamic/Dynamicselectconnection.java
@@ -11,6 +11,7 @@ import playerquests.builder.gui.component.GUISlot;
 import playerquests.builder.gui.function.UpdateScreen;
 import playerquests.builder.quest.QuestBuilder;
 import playerquests.builder.quest.action.QuestAction;
+import playerquests.builder.quest.data.StagePath;
 import playerquests.builder.quest.stage.QuestStage;
 import playerquests.client.ClientDirector;
 
@@ -19,17 +20,17 @@ public class Dynamicselectconnection extends GUIDynamic {
     /**
      * The quest we are editing.
      */
-    QuestBuilder questBuilder;
+    private QuestBuilder questBuilder;
     
     /**
      * The stage that has been selected.
      */
-    QuestStage selectedStage = null;
+    private QuestStage selectedStage = null;
 
     /**
      * The action that has been selected.
      */
-    QuestAction selectedAction = null;
+    private QuestAction selectedAction = null;
 
     /**
      * The code to run on connection select.
@@ -59,7 +60,7 @@ public class Dynamicselectconnection extends GUIDynamic {
                 .setLabel("Just Select This Stage")
                 .setItem("YELLOW_DYE")
                 .onClick(() -> {
-                    this.select(this.selectedStage);
+                    this.select(new StagePath(selectedStage, null)); // just select a stage
                 });
 
             int rangeOffset = 2; // the amount to subtract from the slot number, to get an index from 0
@@ -78,7 +79,7 @@ public class Dynamicselectconnection extends GUIDynamic {
                     .setItem("DETECTOR_RAIL")
                     .onClick(() -> {
                         this.selectedAction = action;
-                        this.select(action);
+                        this.select(new StagePath(selectedStage, action));
                     });
             });
 
@@ -132,9 +133,11 @@ public class Dynamicselectconnection extends GUIDynamic {
      * Called when a connection is selected.
      * @param object the selected stage/action
      */
-    private void select(Object connection) {
+    private void select(StagePath path) {
         if (this.onSelect != null) {
-            onSelect.accept(connection);
+            onSelect.accept(
+                new StagePath(selectedStage, selectedAction)
+            );
         }
 
         new UpdateScreen(
@@ -151,7 +154,7 @@ public class Dynamicselectconnection extends GUIDynamic {
      */
     public Object onSelect(Consumer<Object> onSelect) {
         this.onSelect = onSelect;
-        return this.selectedAction;
+        return onSelect;
     }
     
 }

--- a/src/main/java/playerquests/builder/gui/function/ChatPrompt.java
+++ b/src/main/java/playerquests/builder/gui/function/ChatPrompt.java
@@ -8,7 +8,8 @@ import org.bukkit.event.HandlerList; // to unregister event listener (ChatPrompt
 import org.bukkit.event.Listener; // to register event listener (ChatPromptListener)
 import org.bukkit.event.player.AsyncPlayerChatEvent;
 import org.bukkit.ChatColor; // used to format the chat messages to guide user input/UX
-import org.bukkit.entity.HumanEntity; // refers to the player
+import org.bukkit.entity.HumanEntity; // usually the player
+import org.bukkit.entity.Player; // refers to the player
 
 import playerquests.Core; // used to access the Plugin and KeyHandler instances
 import playerquests.client.ClientDirector; // powers functionality for functions
@@ -31,11 +32,17 @@ public class ChatPrompt extends GUIFunction {
         private ChatPrompt parentClass;
 
         /**
+         * The player this listener is for.
+         */
+        private Player player;
+
+        /**
          * Creates a new listener for chat prompt inputs.
          * @param parent the origin ChatPrompt GUI function
          */
-        public ChatPromptListener(ChatPrompt parent) {
+        public ChatPromptListener(ChatPrompt parent, Player player) {
             this.parentClass = parent;
+            this.player = player;
         }
 
         /**
@@ -44,6 +51,10 @@ public class ChatPrompt extends GUIFunction {
          */
         @EventHandler
         private void onChat(AsyncPlayerChatEvent event) {
+            if (this.player != event.getPlayer()) {
+                return; // do not capture other players events
+            }
+
             event.setCancelled(true); // cancel the chat message from sending to others
             this.parentClass.setResponse(event.getMessage()); // set the user response
             this.parentClass.execute(); // loop back to the function
@@ -110,8 +121,8 @@ public class ChatPrompt extends GUIFunction {
         // set initial values
         this.prompt = (String) params.get(0);
         this.key = (String) params.get(1);
-        this.chatListener = new ChatPromptListener(this);
         this.player = this.director.getPlayer();
+        this.chatListener = new ChatPromptListener(this, Bukkit.getPlayer(this.player.getUniqueId()));
 
         try {
             PluginUtils.validateParams(this.params, String.class, String.class);

--- a/src/main/java/playerquests/builder/gui/function/SelectBlock.java
+++ b/src/main/java/playerquests/builder/gui/function/SelectBlock.java
@@ -102,6 +102,10 @@ public class SelectBlock extends GUIFunction {
                 return; // do not capture other players events
             }
 
+            if (deniedMethods.contains(SelectMethod.CHAT)) {
+                return; // do not continue
+            }
+
             event.setCancelled(true);
 
             Bukkit.getScheduler().runTask(Core.getPlugin(), () -> { // run on next tick

--- a/src/main/java/playerquests/builder/gui/function/SelectLocation.java
+++ b/src/main/java/playerquests/builder/gui/function/SelectLocation.java
@@ -8,6 +8,7 @@ import org.bukkit.Material; // used to create fallback BlockData
 import org.bukkit.block.Block; // data object representing a placed block
 import org.bukkit.block.data.BlockData; // data object representing the metadata of a block
 import org.bukkit.entity.HumanEntity; // usually the player
+import org.bukkit.entity.Player; // refers to the player
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
@@ -32,15 +33,25 @@ public class SelectLocation extends GUIFunction {
         private SelectLocation parentClass;
 
         /**
+         * The player this listener is for.
+         */
+        private Player player;
+
+        /**
          * Creates a new listener for chat prompt inputs.
          * @param parent the origin ChatPrompt GUI function
          */
-        public SelectLocationListener(SelectLocation parent) {
+        public SelectLocationListener(SelectLocation parent, Player player) {
             this.parentClass = parent;
+            this.player = player;
         }
 
         @EventHandler
         private void onBlockPlace(BlockPlaceEvent event) {
+            if (this.player != event.getPlayer()) {
+                return; // do not capture other players events
+            }
+
             event.setCancelled(true);
 
             Block blockPlaced = event.getBlockPlaced();
@@ -115,7 +126,7 @@ public class SelectLocation extends GUIFunction {
         this.director.getGUI().getResult().minimise();
 
         // register events and listener
-        this.locationListener = new SelectLocationListener(this);
+        this.locationListener = new SelectLocationListener(this, Bukkit.getPlayer(this.player.getUniqueId()));
         Bukkit.getPluginManager().registerEvents(this.locationListener, Core.getPlugin());
 
         // mark this function class as setup

--- a/src/main/java/playerquests/builder/quest/QuestBuilder.java
+++ b/src/main/java/playerquests/builder/quest/QuestBuilder.java
@@ -8,6 +8,8 @@ import java.util.UUID;
 import java.util.stream.Collectors; // accumulating elements from a stream into a type
 import java.util.stream.IntStream; // used to iterate over a range
 
+import org.bukkit.Bukkit;
+
 import com.fasterxml.jackson.annotation.JsonIgnore; // remove fields from serialising to json
 import com.fasterxml.jackson.annotation.JsonProperty; // for declaring a field as a json property
 
@@ -317,6 +319,8 @@ public class QuestBuilder {
      */
     public void removeNPC(QuestNPC npc) {
         this.questNPCs.remove(npc.getID());
+
+        npc.refund(Bukkit.getPlayer(this.getDirector().getPlayer().getUniqueId()));
     }
 
     /**

--- a/src/main/java/playerquests/builder/quest/QuestBuilder.java
+++ b/src/main/java/playerquests/builder/quest/QuestBuilder.java
@@ -338,7 +338,8 @@ public class QuestBuilder {
             this.entryPoint,
             this.questNPCs,
             this.questPlan,
-            this.universal ? null : this.director.getPlayer().getUniqueId()
+            this.universal ? null : this.director.getPlayer().getUniqueId(),
+            true // always toggle cloned quests on when freshly cloned
         );
 
         // set this quest as in-focus to the creator

--- a/src/main/java/playerquests/builder/quest/QuestBuilder.java
+++ b/src/main/java/playerquests/builder/quest/QuestBuilder.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore; // remove fields from serial
 import com.fasterxml.jackson.annotation.JsonProperty; // for declaring a field as a json property
 
 import playerquests.Core; // gets the KeyHandler singleton
+import playerquests.builder.quest.data.StagePath;
 import playerquests.builder.quest.npc.QuestNPC; // quest npc builder
 import playerquests.builder.quest.stage.QuestStage; // quest stage builder
 import playerquests.client.ClientDirector; // abstractions for plugin functionality
@@ -48,7 +49,7 @@ public class QuestBuilder {
     /**
      * Entry point for the quest.
      */
-    private QuestStage entryPoint;
+    private StagePath entryPoint;
 
     /**
      * Map of the NPC characters.
@@ -83,11 +84,17 @@ public class QuestBuilder {
         this.director = director;
 
         // default entry point as first stage (stage_0)
-        this.entryPoint = new QuestStage(this.build(), 0);
-        director.setCurrentInstance(this.entryPoint); // make it modifiable
+        QuestStage stage = new QuestStage(this.build(), 0);
+        this.entryPoint = new StagePath(
+            stage,
+            null
+        );
+        
+        // make it modifiable
+        director.setCurrentInstance(stage);
 
         // add default entry point stage to questPlan map
-        this.questPlan.put(this.entryPoint.getID(), this.entryPoint);
+        this.questPlan.put(stage.getID(), stage);
 
         // set as the current quest in the director
         director.setCurrentInstance(this);
@@ -108,8 +115,9 @@ public class QuestBuilder {
             this.title = product.getTitle();
 
             // add the entry point stage from the product
-            this.entryPoint = product.getStages().get(product.getEntry());
-            director.setCurrentInstance(this.entryPoint); // make it modifiable
+            QuestStage entryStage = product.getStages().get(product.getEntry().getStage());
+            this.entryPoint = new StagePath(entryStage, null);
+            director.setCurrentInstance(entryStage); // make it modifiable
 
             // add the stages from the product
             this.questPlan = product.getStages();
@@ -208,7 +216,7 @@ public class QuestBuilder {
      */
     @JsonProperty("entry")
     public String getEntryPointString() {
-        return this.entryPoint.getID();
+        return this.entryPoint.toString();
     }
 
     /**
@@ -217,8 +225,8 @@ public class QuestBuilder {
      * Should be a stage.
      * @param stage what the entry point stage is
      */
-    public void setEntryPoint(QuestStage stage) {
-        this.entryPoint = stage;
+    public void setEntryPoint(StagePath path) {
+        this.entryPoint = path;
     }
 
     /**

--- a/src/main/java/playerquests/builder/quest/QuestBuilder.java
+++ b/src/main/java/playerquests/builder/quest/QuestBuilder.java
@@ -1,5 +1,6 @@
 package playerquests.builder.quest;
 
+import java.util.Comparator;
 import java.util.HashMap; // hash table map type
 import java.util.LinkedList;
 import java.util.Map; // generic map type
@@ -235,7 +236,14 @@ public class QuestBuilder {
      */
     @JsonIgnore
     public LinkedList<String> getStages() {
-        return new LinkedList<String>(this.questPlan.keySet());
+        // create an ordered list of stages, ordered by stage_[this number]
+        LinkedList<String> orderedList = this.questPlan.keySet().stream()
+            .map(stage -> stage.split("_"))
+            .sorted(Comparator.comparingInt(parts -> Integer.parseInt(parts[1])))
+            .map(parts -> String.join("_", parts))
+            .collect(Collectors.toCollection(LinkedList::new));
+
+        return orderedList;
     }
 
     /**

--- a/src/main/java/playerquests/builder/quest/action/Speak.java
+++ b/src/main/java/playerquests/builder/quest/action/Speak.java
@@ -5,7 +5,6 @@ import java.util.Arrays; // generic array type
 import java.util.List; // generic list type
 import java.util.Optional;
 
-import org.bukkit.Bukkit; // bukkit API
 import org.bukkit.entity.Player; // represents a bukkit player
 
 import playerquests.builder.quest.data.ActionOption; // enums for possible options to add to an action
@@ -42,7 +41,7 @@ public class Speak extends QuestAction {
 
     @Override
     public void Run(QuestClient quester) {
-        Player player = Bukkit.getPlayer(quester.getPlayer().getUniqueId());
+        Player player = quester.getPlayer();
 
         // insert empty dialogue if none set
         if (this.dialogue == null) {

--- a/src/main/java/playerquests/builder/quest/data/ConnectionsData.java
+++ b/src/main/java/playerquests/builder/quest/data/ConnectionsData.java
@@ -7,9 +7,9 @@ import com.fasterxml.jackson.annotation.JsonIgnore; // used to ignore fields in 
  * to form a network/quest plan.
  */
 public class ConnectionsData {
-    private String next;
-    private String curr;
-    private String prev;
+    private StagePath next;
+    private StagePath curr;
+    private StagePath prev;
 
     /**
      * Defaut constructor (for Jackson)
@@ -23,7 +23,7 @@ public class ConnectionsData {
      * @param curr where to return to if the stage is exited
      * @param prev where to go if the stage fails
      */
-    public ConnectionsData(String next, String curr, String prev) {
+    public ConnectionsData(StagePath next, StagePath curr, StagePath prev) {
         this.next = next;
         this.curr = curr;
         this.prev = prev;
@@ -33,7 +33,7 @@ public class ConnectionsData {
      * Gets the next quest stage or action.
      * @return next stage or action.
      */
-    public String getNext() {
+    public StagePath getNext() {
         return this.next;
     }
 
@@ -41,7 +41,7 @@ public class ConnectionsData {
      * Sets the next quest stage or action.
      * @param next a quest stage or action.
      */
-    public void setNext(String next) {
+    public void setNext(StagePath next) {
         this.next = next;
     }
 
@@ -49,7 +49,7 @@ public class ConnectionsData {
      * Gets the on-exit quest stage or action.
      * @return on-exit stage or action.
      */
-    public String getCurr() {
+    public StagePath getCurr() {
         return this.curr;
     }
 
@@ -57,7 +57,7 @@ public class ConnectionsData {
      * Sets the on-exit quest stage or action.
      * @param next a quest stage or action.
      */
-    public void setCurr(String curr) {
+    public void setCurr(StagePath curr) {
         this.curr = curr;
     }
 
@@ -65,7 +65,7 @@ public class ConnectionsData {
      * Gets the prior quest stage or action.
      * @return prior stage or action.
      */
-    public String getPrev() {
+    public StagePath getPrev() {
         return this.prev;
     }
 
@@ -73,7 +73,7 @@ public class ConnectionsData {
      * Sets the prior quest stage or action.
      * @param next a quest stage or action.
      */
-    public void setPrev(String prev) {
+    public void setPrev(StagePath prev) {
         this.prev = prev;
     }
 

--- a/src/main/java/playerquests/builder/quest/data/StagePath.java
+++ b/src/main/java/playerquests/builder/quest/data/StagePath.java
@@ -1,0 +1,143 @@
+package playerquests.builder.quest.data;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import playerquests.builder.quest.action.QuestAction;
+import playerquests.builder.quest.stage.QuestStage;
+import playerquests.product.Quest;
+
+/**
+ * Represents a path within a quest, consisting of a stage and optionally an action.
+ * 
+ * This class provides various constructors for creating a {@code StagePath} from different types of input
+ * and methods for retrieving the stage and action details.
+ * 
+ * The {@code StagePath} can be initialized using:
+ * <ul>
+ *   <li>A single string path (suitable for Jackson deserialization), where the string is split by a period (".") to determine the stage and action.</li>
+ *   <li>Objects of type {@code QuestStage} and {@code QuestAction}, where the IDs of these objects are used to set the stage and action.</li>
+ *   <li>Two separate strings for stage and action.</li>
+ * </ul>
+ * 
+ * This class also includes methods to retrieve the corresponding {@code QuestStage} and {@code QuestAction}
+ * objects from a {@code Quest} based on the stored IDs.
+ */
+public class StagePath {
+    private String stage;
+    private String action;
+
+    /**
+     * Constructs a new {@code StagePath} from string values. 
+     * (good for Jackson deserialisation).
+     * 
+     * @param path the StagePath as a string
+     * @param id the Quest ID as a string
+     */
+    public StagePath(String path) {
+        // segment[0] = stage_?
+        // segment[1] (if exists) = action_?
+        String[] segments = path.split("\\.");
+
+        // for backwards compatibility and dummies; segment[0] = action_?
+        if (segments[0].contains("action")) {
+            this.action = segments[0];
+            return;
+        }
+
+        // for correct string representation/template behaviour
+        this.stage = segments[0];
+        this.action = null;
+
+        if (segments.length > 1) {
+            this.action = segments[1]; 
+        }
+    }
+
+    /**
+     * Constructs a new {@code StagePath} from actual objects.
+     * 
+     * @param path the StagePath as a string
+     * @param id the Quest ID as a string
+     */
+    public StagePath(QuestStage stage, QuestAction action) {
+        this.stage = stage.getID();
+        this.action = null;
+
+        if (action != null) {
+            this.action = action.getID();
+        }
+    }
+
+    /**
+     * Constructs a new {@code StagePath} from disjoined strings.
+     * 
+     * @param path the StagePath as a string
+     * @param id the Quest ID as a string
+     */
+    public StagePath(String stage, String action) {
+        this.stage = stage;
+        this.action = action;
+    }
+
+    /**
+     * Returns the quest stage ID.
+     *
+     * @return the quest stage ID
+     */
+    public String getStage() {
+        return stage;
+    }
+
+    /**
+     * Returns the quest stage object.
+     *
+     * @return the quest stage
+     */
+    public QuestStage getStage(Quest quest) {
+        return quest.getStages().get(stage);
+    }
+
+    /**
+     * Returns the quest action ID.
+     *
+     * @return the quest action ID
+     */
+    public String getAction() {
+        return stage;
+    }
+
+    /**
+     * Returns the quest action object.
+     *
+     * @return the quest action
+     */
+    public QuestAction getAction(Quest quest) {
+        QuestStage stage;
+
+        if (this.stage == null) {
+            stage = quest.getStages().values().iterator().next(); // just assume first stage
+        } else {
+            stage = quest.getStages().get(this.stage);
+        }
+
+        if (this.action == null) {
+            return stage.getEntryPoint().getAction(quest); // try next entry point
+        }
+
+        return stage.getActions().get(action);
+    }
+
+    /**
+     * Returns a string representation of this {@code StagePath}, in the format
+     * "[stage ID].[action ID]" or "[stage ID]".
+     *
+     * @return a string representation of this stage and action reference
+     */
+    @JsonValue
+    public String toString() {
+        return String.format("%s%s",
+            stage != null ? stage : "stage_0",
+            action != null ? "."+action : ""
+        );
+    }
+}

--- a/src/main/java/playerquests/builder/quest/data/StagePath.java
+++ b/src/main/java/playerquests/builder/quest/data/StagePath.java
@@ -1,5 +1,7 @@
 package playerquests.builder.quest.data;
 
+import javax.annotation.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonValue;
 
 import playerquests.builder.quest.action.QuestAction;
@@ -59,7 +61,7 @@ public class StagePath {
      * @param path the StagePath as a string
      * @param id the Quest ID as a string
      */
-    public StagePath(QuestStage stage, QuestAction action) {
+    public StagePath(QuestStage stage, @Nullable QuestAction action) {
         this.stage = stage.getID();
         this.action = null;
 
@@ -74,7 +76,7 @@ public class StagePath {
      * @param path the StagePath as a string
      * @param id the Quest ID as a string
      */
-    public StagePath(String stage, String action) {
+    public StagePath(String stage, @Nullable String action) {
         this.stage = stage;
         this.action = action;
     }
@@ -85,7 +87,7 @@ public class StagePath {
      * @return the quest stage ID
      */
     public String getStage() {
-        return stage;
+        return stage != null ? stage : "stage_0";
     }
 
     /**
@@ -94,6 +96,11 @@ public class StagePath {
      * @return the quest stage
      */
     public QuestStage getStage(Quest quest) {
+        // if somehow the stage is null
+        if (stage == null) {
+            return quest.getStages().values().iterator().next();
+        }
+
         return quest.getStages().get(stage);
     }
 
@@ -103,7 +110,7 @@ public class StagePath {
      * @return the quest action ID
      */
     public String getAction() {
-        return stage;
+        return action != null ? action : null;
     }
 
     /**
@@ -112,13 +119,7 @@ public class StagePath {
      * @return the quest action
      */
     public QuestAction getAction(Quest quest) {
-        QuestStage stage;
-
-        if (this.stage == null) {
-            stage = quest.getStages().values().iterator().next(); // just assume first stage
-        } else {
-            stage = quest.getStages().get(this.stage);
-        }
+        QuestStage stage = this.getStage(quest);
 
         if (this.action == null) {
             return stage.getEntryPoint().getAction(quest); // try next entry point
@@ -135,8 +136,10 @@ public class StagePath {
      */
     @JsonValue
     public String toString() {
+        String action = this.getAction(); // will be action if it exists, otherwise null
+
         return String.format("%s%s",
-            stage != null ? stage : "stage_0",
+            this.getStage(),
             action != null ? "."+action : ""
         );
     }

--- a/src/main/java/playerquests/builder/quest/npc/BlockNPC.java
+++ b/src/main/java/playerquests/builder/quest/npc/BlockNPC.java
@@ -7,6 +7,7 @@ import org.bukkit.block.data.BlockData; // block representing this NPC
 import com.fasterxml.jackson.annotation.JsonIgnore; // to ignore serialising properties
 import com.fasterxml.jackson.annotation.JsonProperty; // to set how a property serialises
 
+import playerquests.Core;
 import playerquests.utility.singleton.PlayerQuests;
 
 public class BlockNPC extends NPCType {
@@ -73,7 +74,9 @@ public class BlockNPC extends NPCType {
     @Override
     @JsonIgnore
     public void place() {
-        PlayerQuests.getInstance().putBlockNPC(this);
+        Bukkit.getScheduler().runTask(Core.getPlugin(), () -> {
+            PlayerQuests.getInstance().putBlockNPC(this);
+        });   
     }
 
     /**

--- a/src/main/java/playerquests/builder/quest/npc/BlockNPC.java
+++ b/src/main/java/playerquests/builder/quest/npc/BlockNPC.java
@@ -3,6 +3,8 @@ package playerquests.builder.quest.npc;
 import org.bukkit.Bukkit;
 import org.bukkit.Material; // deprecated: material representing the block, representing this NPC
 import org.bukkit.block.data.BlockData; // block representing this NPC
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
 
 import com.fasterxml.jackson.annotation.JsonIgnore; // to ignore serialising properties
 import com.fasterxml.jackson.annotation.JsonProperty; // to set how a property serialises
@@ -88,5 +90,14 @@ public class BlockNPC extends NPCType {
         this.npc.setLocation(null);
 
         PlayerQuests.getInstance().putBlockNPC(this);
+    }
+
+    @Override
+    @JsonIgnore
+    public void refund(Player player) {
+        // return the NPC block to the player
+        player.getInventory().addItem(
+            new ItemStack(this.getBlock().getMaterial())
+        );
     }
 }

--- a/src/main/java/playerquests/builder/quest/npc/NPCType.java
+++ b/src/main/java/playerquests/builder/quest/npc/NPCType.java
@@ -3,6 +3,8 @@ package playerquests.builder.quest.npc;
 import java.util.ArrayList; // array type of list
 import java.util.List; // generic list type
 
+import org.bukkit.entity.Player;
+
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
@@ -123,5 +125,12 @@ public class NPCType {
      */
     public void remove() {
         throw new IllegalStateException("Tried to remove an NPC that has not been given a type. (or the type has not correctly overriden the place method)");
+    }
+
+    /**
+     * Refund the resources used for the NPC.
+     */
+    public void refund(Player player) {
+        throw new IllegalStateException("Tried to refund an NPC that has not been given a type. (or the type has not correctly overriden the place method)");
     }
 }

--- a/src/main/java/playerquests/builder/quest/npc/QuestNPC.java
+++ b/src/main/java/playerquests/builder/quest/npc/QuestNPC.java
@@ -6,6 +6,7 @@ import org.bukkit.Bukkit; // bukkit singleton
 import org.bukkit.Material; // for if NPC is a block
 import org.bukkit.block.data.BlockData;
 import org.bukkit.entity.HumanEntity; // the player
+import org.bukkit.entity.Player;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonIgnore; // ignore a field when serialising to a JSON object
@@ -280,5 +281,10 @@ public class QuestNPC {
      */
     public void setQuest(Quest quest) {
         this.quest = quest;
+    }
+
+    @JsonIgnore
+    public void refund(Player player) {
+        this.getAssigned().refund(player);
     }
 }

--- a/src/main/java/playerquests/builder/quest/npc/QuestNPC.java
+++ b/src/main/java/playerquests/builder/quest/npc/QuestNPC.java
@@ -207,6 +207,12 @@ public class QuestNPC {
      */
     @JsonIgnore
     public void assign(NPCType npcType) {
+        Player player = Bukkit.getPlayer(this.quest.getCreator());
+
+        if (this.assigned != null && player != null) { // if already assigned to something
+            this.refund(player);
+        }
+
         this.assigned = npcType;
     }
 

--- a/src/main/java/playerquests/builder/quest/npc/QuestNPC.java
+++ b/src/main/java/playerquests/builder/quest/npc/QuestNPC.java
@@ -17,7 +17,9 @@ import playerquests.builder.quest.QuestBuilder;
 import playerquests.builder.quest.data.LocationData; // quest entity locations
 import playerquests.client.ClientDirector; // for controlling the plugin
 import playerquests.product.Quest;
-import playerquests.utility.ChatUtils; // sends error messages to player
+import playerquests.utility.ChatUtils.MessageBuilder;
+import playerquests.utility.ChatUtils.MessageStyle;
+import playerquests.utility.ChatUtils.MessageTarget;
 import playerquests.utility.ChatUtils.MessageType;
 import playerquests.utility.annotation.Key; // key-value pair annottation
 
@@ -162,42 +164,41 @@ public class QuestNPC {
     public boolean isValid() {
         UUID questCreator = quest.getCreator();
         HumanEntity player = null;
+        MessageBuilder response = new MessageBuilder("Something is wrong with a quest NPC") // default message; default sends to console
+            .type(MessageType.ERROR)
+            .target(MessageTarget.CONSOLE)
+            .style(MessageStyle.PLAIN);
+        Boolean isValid = true; // assume is valid
+
+        if (this.name == null) {
+            response.content("The NPC name must be set");
+            isValid = false;
+        }
+
+        if (this.assigned == null) {
+            response.content("The NPC must be assigned to a type");
+            isValid = false;
+        }
+
+        if (this.location == null) {
+            response.content("The NPC must be placed at a location");
+            isValid = false;
+        }
 
         // when there is a quest creator, try set player object from creator UUID
         if (questCreator != null) {
             player = Bukkit.getPlayer(quest.getCreator()); // the player to send invalid npc messages to
-        }
-
-        // when player not findable
-        if (player == null) {
-            return false;
-        }
-
-        if (this.name == null) {
-            ChatUtils.message("The NPC name must be set")
+            response // send a message to the player
                 .player(player)
-                .type(MessageType.WARN)
-                .send();
-            return false;
+                .style(MessageStyle.PRETTY);
         }
 
-        if (this.assigned == null) {
-            ChatUtils.message("The NPC must be assigned to a type")
-                .player(player)
-                .type(MessageType.WARN)
-                .send();
-            return false;
+        // send the response
+        if (!isValid) {
+            response.send(); // send our :( message
         }
 
-        if (this.location == null) {
-            ChatUtils.message("The NPC must be placed at a location")
-                .player(player)
-                .type(MessageType.WARN)
-                .send();
-            return false;
-        }
-
-        return true;
+        return isValid;
     }
     
     /**

--- a/src/main/java/playerquests/builder/quest/stage/QuestStage.java
+++ b/src/main/java/playerquests/builder/quest/stage/QuestStage.java
@@ -170,7 +170,6 @@ public class QuestStage {
      */
     public void removeAction(QuestAction action) {
         this.actions.remove(action.getID());
-        this.quest.save();
     }
 
     /**

--- a/src/main/java/playerquests/builder/quest/stage/QuestStage.java
+++ b/src/main/java/playerquests/builder/quest/stage/QuestStage.java
@@ -12,6 +12,7 @@ import playerquests.Core; // accessing plugin singeltons
 import playerquests.builder.quest.action.None; // default QuestAction type
 import playerquests.builder.quest.action.QuestAction; // abstract class for quest actions
 import playerquests.builder.quest.data.ConnectionsData;
+import playerquests.builder.quest.data.StagePath;
 import playerquests.product.Quest; // back reference to quest this stage belongs to
 import playerquests.utility.annotation.Key; // to associate a key name with a method
 
@@ -48,7 +49,7 @@ public class QuestStage {
      * Entry point action for the stage.
      */
     @JsonProperty("entry")
-    private String entryPoint;
+    private StagePath entryPoint;
 
     /**
      * The connections for the quest stage.
@@ -71,10 +72,10 @@ public class QuestStage {
         Core.getKeyHandler().registerInstance(this); // add the current quest stage to be accessed with key-pair syntax
 
         // create the default first action
-        String action = new None(this).submit().getID();
+        QuestAction action = new None(this).submit();
 
         // set the default first action as the default entry point
-        this.setEntryPoint(action);
+        this.setEntryPoint(new StagePath(this, action));
     }
 
     /**
@@ -92,10 +93,10 @@ public class QuestStage {
         Core.getKeyHandler().registerInstance(this); // add the current quest stage to be accessed with key-pair syntax
 
         // create the default first action
-        String action = new None(this).submit().getID();
+        QuestAction action = new None(this).submit();
 
         // set the default first action as the default entry point
-        this.setEntryPoint(action);
+        this.setEntryPoint(new StagePath(this, action));
     }
 
     /**
@@ -176,8 +177,8 @@ public class QuestStage {
      * Sets the first action executed when this stage is reached.
      * @param action a quest action id
      */
-    public void setEntryPoint(String action) {
-        this.entryPoint = action;
+    public void setEntryPoint(StagePath path) {
+        this.entryPoint = path;
     }
 
     /**
@@ -185,8 +186,8 @@ public class QuestStage {
      * @return a quest action id
      */
     @JsonIgnore
-    public QuestAction getEntryPoint() {
-        return this.actions.get(this.entryPoint);
+    public StagePath getEntryPoint() {
+        return this.entryPoint;
     }
 
     /**
@@ -210,8 +211,8 @@ public class QuestStage {
         newActionInstance.setID(currentAction); // update the ID in the action local
         this.actions.replace(currentAction, newActionInstance); // replace in main list
 
-        if (currentAction.equals(this.entryPoint)) {
-            this.entryPoint = newActionInstance.getID();
+        if (currentAction.equals(this.entryPoint.getAction())) {
+            this.entryPoint = new StagePath(this, newActionInstance);
         }
     }
 

--- a/src/main/java/playerquests/client/ClientDirector.java
+++ b/src/main/java/playerquests/client/ClientDirector.java
@@ -5,7 +5,6 @@ import java.util.HashMap; // holds the current instances
 import org.bukkit.entity.HumanEntity; // the player who controls the client
 
 import playerquests.builder.gui.GUIBuilder; // class to control and get GUI product
-import playerquests.builder.quest.QuestBuilder; // class to control and get Quest product
 
 /**
  * Class which provides simple abstractions for clients to use.
@@ -44,7 +43,6 @@ public class ClientDirector {
     private void validateCurrentInstances() {
         // keep a default GUIBuilder available 
         currentInstances.putIfAbsent(GUIBuilder.class, new GUIBuilder(this));
-        currentInstances.putIfAbsent(QuestBuilder.class, new QuestBuilder(this));
     }
 
     /**

--- a/src/main/java/playerquests/client/ClientDirector.java
+++ b/src/main/java/playerquests/client/ClientDirector.java
@@ -5,13 +5,14 @@ import java.util.HashMap; // holds the current instances
 import org.bukkit.entity.HumanEntity; // the player who controls the client
 
 import playerquests.builder.gui.GUIBuilder; // class to control and get GUI product
+import playerquests.utility.singleton.PlayerQuests; // the main plugin class
 
 /**
  * Class which provides simple abstractions for clients to use.
  * <p>
  * Used to control the plugin and keep reference of client state.
  */
-public class ClientDirector {
+public class ClientDirector extends Director {
     /**
      * One of every key-mutable instance
      */
@@ -32,6 +33,9 @@ public class ClientDirector {
 
         // validate the current instances map is correct/has everything
         this.validateCurrentInstances();
+
+        // store the director
+        PlayerQuests.getInstance().addDirector(this);
     }
 
     /**
@@ -118,5 +122,10 @@ public class ClientDirector {
     public void clearCurrentInstances() {
         this.currentInstances.clear();
         this.validateCurrentInstances();
+    }
+
+    @Override
+    public void close() {
+        this.getGUI().getResult().close();
     }
 }

--- a/src/main/java/playerquests/client/Director.java
+++ b/src/main/java/playerquests/client/Director.java
@@ -1,0 +1,8 @@
+package playerquests.client;
+
+public abstract class Director {
+    /**
+     * Closes the director.
+     */
+    public abstract void close();
+}

--- a/src/main/java/playerquests/client/gui/listener/GUIListener.java
+++ b/src/main/java/playerquests/client/gui/listener/GUIListener.java
@@ -168,12 +168,13 @@ public class GUIListener implements Listener {
      */
     @EventHandler
     public void onClickItem(InventoryClickEvent event) {
-        if (!this.isGUIInventory(event)) {
+        Player player = Bukkit.getPlayer(event.getView().getPlayer().getUniqueId());
+
+        if (!this.isGUIInventory(event) || !this.isGUI(player)) {
             return; // exit if the inventory is GUI
         }
 
         Integer slotPosition = event.getSlot() + 1; // get the real position of the slot
-        Player player = Bukkit.getPlayer(event.getView().getPlayer().getUniqueId());
         GUIBuilder builder = builders.get(player);
         GUISlot slot = builder.getSlot(slotPosition); // get the slot data
 

--- a/src/main/java/playerquests/client/quest/QuestClient.java
+++ b/src/main/java/playerquests/client/quest/QuestClient.java
@@ -15,6 +15,7 @@ import playerquests.Core;
 import playerquests.builder.quest.action.QuestAction; // quest action
 import playerquests.builder.quest.data.ConnectionsData;
 import playerquests.builder.quest.data.LocationData;
+import playerquests.builder.quest.data.StagePath;
 import playerquests.builder.quest.npc.QuestNPC; // represents quest npcs
 import playerquests.product.Quest; // represents a player quest
 import playerquests.utility.singleton.Database; // the preservation/backup store
@@ -128,6 +129,7 @@ public class QuestClient {
 
         // NPC magic! (assigning an action to an npc based on progress in quest)
         // get each quest progress
+        Map<QuestNPC, QuestAction> actionNPCsLocal = new HashMap<>(); 
         this.diary.getQuestProgress().forEach((quest, connections) -> {
 
             // get the action we are up to in this quest to..
@@ -142,11 +144,14 @@ public class QuestClient {
             }
             
             // ..and submit the 'action <-> NPC' association
-            this.actionNPC.put(
+            actionNPCsLocal.put(
                 npc,
                 action
             );
         });
+
+        // submit the NPCs we found progress for
+        this.actionNPC.putAll(actionNPCsLocal);
 
         this.showFX();
     }
@@ -176,11 +181,11 @@ public class QuestClient {
         }
 
         // Prepare interaction/next step vars
-        String next_step = action.getConnections().getNext(); // could be action_?, stage_?
+        StagePath next_step = action.getConnections().getNext(); // could be action_?, stage_?
         ConnectionsData diaryConnections = this.diary.getQuestProgress(quest); // read current position in quest
 
         if (diaryConnections == null) { // if no progress for this quest found
-            diaryConnections = quest.getStages().get(quest.getEntry()).getConnections(); // get quest entry point position
+            diaryConnections = quest.getStages().get(quest.getEntry().getStage()).getConnections(); // get quest entry point position
         }
 
         // move forward through connections

--- a/src/main/java/playerquests/client/quest/QuestClient.java
+++ b/src/main/java/playerquests/client/quest/QuestClient.java
@@ -169,7 +169,6 @@ public class QuestClient {
         // Find the action associated with this npc in a helper map
         Quest quest = QuestRegistry.getInstance().getQuest(npc.getQuest().getID()); // inefficient way, but npc.getQuest() was returning bad data
         QuestAction action = this.actionNPC.get(npc);
-        System.out.println("interact questclient got quest: " + quest);
 
         // Don't continue if there is no quest or action for this interaction
         if (action == null || quest == null) {

--- a/src/main/java/playerquests/client/quest/QuestClient.java
+++ b/src/main/java/playerquests/client/quest/QuestClient.java
@@ -39,7 +39,7 @@ public class QuestClient {
     /**
      * If the user has world effects on.
      */
-    private Boolean fx;
+    private Boolean fx = true;
 
     /**
      * The quests available to play (which haven't been started already).
@@ -89,6 +89,9 @@ public class QuestClient {
 
         // initiate personal quest world state
         this.showFX(); // visual quest indicators
+
+        // first world update
+        this.update();
     }
 
     /**
@@ -169,6 +172,10 @@ public class QuestClient {
      * These are called 'helper maps' here,
      */
     public void update() {
+        if (this.diary == null) {
+            return;
+        }
+
         // clear the helper maps
         entryStages.clear();
         entryActions.clear();

--- a/src/main/java/playerquests/client/quest/QuestClient.java
+++ b/src/main/java/playerquests/client/quest/QuestClient.java
@@ -17,6 +17,7 @@ import playerquests.builder.quest.data.ConnectionsData;
 import playerquests.builder.quest.data.LocationData;
 import playerquests.builder.quest.npc.QuestNPC; // represents quest npcs
 import playerquests.product.Quest; // represents a player quest
+import playerquests.utility.singleton.Database; // the preservation/backup store
 import playerquests.utility.singleton.QuestRegistry;
 
 /**
@@ -191,6 +192,9 @@ public class QuestClient {
 
             // update the diary
             this.diary.setQuestProgress(quest, updatedConnections);
+
+            // update the db for preservation sake
+            Database.getInstance().setDiaryQuest(this.diary, quest, updatedConnections);
 
             // remove NPCs pending interaction marker/sparkle
             this.actionNPC.remove(npc);

--- a/src/main/java/playerquests/client/quest/QuestClient.java
+++ b/src/main/java/playerquests/client/quest/QuestClient.java
@@ -17,6 +17,7 @@ import playerquests.builder.quest.data.ConnectionsData;
 import playerquests.builder.quest.data.LocationData;
 import playerquests.builder.quest.npc.QuestNPC; // represents quest npcs
 import playerquests.product.Quest; // represents a player quest
+import playerquests.utility.singleton.QuestRegistry;
 
 /**
  * Quest tracking and interactions for each player.
@@ -165,11 +166,12 @@ public class QuestClient {
      */
     public void interact(QuestNPC npc) {
         // Find the action associated with this npc in a helper map
+        Quest quest = QuestRegistry.getInstance().getQuest(npc.getQuest().getID()); // inefficient way, but npc.getQuest() was returning bad data
         QuestAction action = this.actionNPC.get(npc);
-        Quest quest = npc.getQuest();
+        System.out.println("interact questclient got quest: " + quest);
 
-        // Don't continue if there is no action for this interaction
-        if (action == null) {
+        // Don't continue if there is no quest or action for this interaction
+        if (action == null || quest == null) {
             return;
         }
 

--- a/src/main/java/playerquests/client/quest/QuestDiary.java
+++ b/src/main/java/playerquests/client/quest/QuestDiary.java
@@ -63,7 +63,7 @@ public class QuestDiary {
                 // (we know it's unstarted because we are using the quest's default ConnectionsData, 
                 // ConnectionsData is the thing that tracks quest progress. It does it by identifying the
                 // previous, current and next action/stage).
-                this.questProgress.putIfAbsent(quest, quest.getConnections()); // TODO: ensure this isn't duplicating things
+                this.questProgress.putIfAbsent(quest, quest.getConnections());
             });
 
             client.update();

--- a/src/main/java/playerquests/client/quest/QuestDiary.java
+++ b/src/main/java/playerquests/client/quest/QuestDiary.java
@@ -57,6 +57,15 @@ public class QuestDiary {
         // instantiate quest progress from the db
         // and update the client when we have results!
         loadQuestProgress().thenRun(() -> {
+            // fill in un-completed/un-started quests
+            QuestRegistry.getInstance().getAllQuests().values().stream().forEach((quest) -> {
+                // put the quest from the start 
+                // (we know it's unstarted because we are using the quest's default ConnectionsData, 
+                // ConnectionsData is the thing that tracks quest progress. It does it by identifying the
+                // previous, current and next action/stage).
+                this.questProgress.putIfAbsent(quest, quest.getConnections()); // TODO: ensure this isn't duplicating things
+            });
+
             client.update();
         });
     }

--- a/src/main/java/playerquests/client/quest/QuestDiary.java
+++ b/src/main/java/playerquests/client/quest/QuestDiary.java
@@ -66,14 +66,11 @@ public class QuestDiary {
      * Should only run on first ever instantiation.
      */
     private CompletableFuture<Void> loadQuestProgress() {
-        System.out.println("before: " + this.questProgress);
-        
         return CompletableFuture.supplyAsync(() -> {
             try {
                 // Retrieve the quest progress,
                 // and store locally
                 this.questProgress = Database.getInstance().getQuestProgress(this);
-                System.out.println("after: " + this.questProgress);
             } catch (Exception e) {
                 // Report something critical went wrong
                 ChatUtils.message("Failed to load quest progress for: " + this.getPlayer() + ", " + e)
@@ -84,7 +81,6 @@ public class QuestDiary {
             }
 
             // Returning no data, only the completion handler
-            System.out.println("doin return thing");
             return null;
         });
     }

--- a/src/main/java/playerquests/client/quest/QuestDiary.java
+++ b/src/main/java/playerquests/client/quest/QuestDiary.java
@@ -10,6 +10,7 @@ import org.bukkit.entity.Player; // the in-game player object
 
 import playerquests.builder.quest.action.QuestAction; // quest product: actions
 import playerquests.builder.quest.data.ConnectionsData; // quest product: what action/stage connects to what
+import playerquests.builder.quest.data.StagePath;
 import playerquests.builder.quest.stage.QuestStage; // quest product: stages
 import playerquests.product.Quest; // quest product
 import playerquests.utility.ChatUtils; // sending messages systematically
@@ -164,17 +165,13 @@ public class QuestDiary {
      * @return quest stage object
      */
     public QuestStage getStage(Quest quest, Boolean next) {
-        String curr = this.getQuestProgress(quest).getCurr();
+        ConnectionsData progress = this.getQuestProgress(quest);
 
-        // if the current is an action
-        if (curr.contains("action")) {
-            return quest
-                .getActions().get(curr) // retrieve the action we are at
-                .getStage(); // retrieve the stage the action we are at belongs to
+        if (next) {
+            return progress.getNext().getStage(quest);
         }
 
-        // otherwise: just get the stage :)
-        return quest.getStages().get(curr);
+        return progress.getCurr().getStage(quest);
     }
 
     /**
@@ -195,17 +192,16 @@ public class QuestDiary {
      * @return quest action object
      */
     public QuestAction getAction(Quest quest, Boolean next) {
-        String curr = this.getQuestProgress(quest).getCurr();
+        ConnectionsData progress = this.getQuestProgress(quest);
+        StagePath point = next ? progress.getNext() : progress.getCurr();
 
-        // if the current is a stage
-        if (curr.contains("stage")) {
-            return quest
-                .getStages().get(curr) // retrieve the stage we are at
-                .getEntryPoint(); // retrieve the first action in the stage
+        // if no action found
+        if (point.getAction(quest) == null) {
+            return point.getStage(quest).getEntryPoint().getAction(quest);
         }
 
-        // otherwise: just get the action :)
-        return quest.getActions().get(curr);
+        // otherwise just return action
+        return point.getAction(quest);
     }
 
     public void setQuestProgress(Quest quest, ConnectionsData connections) {

--- a/src/main/java/playerquests/product/Quest.java
+++ b/src/main/java/playerquests/product/Quest.java
@@ -348,4 +348,10 @@ public class Quest {
 
         return isValid;
     }
+
+    @JsonIgnore
+    @Override
+    public String toString() {
+        return String.format("%s=%s", super.toString(), this.getID());
+    }
 }

--- a/src/main/java/playerquests/product/Quest.java
+++ b/src/main/java/playerquests/product/Quest.java
@@ -41,7 +41,6 @@ import playerquests.utility.singleton.QuestRegistry; // multi-threaded quest sto
  */
 @JsonIgnoreProperties(ignoreUnknown = true) // ignore id
 public class Quest {
-
     /**
      * The label of this quest.
      */

--- a/src/main/java/playerquests/product/Quest.java
+++ b/src/main/java/playerquests/product/Quest.java
@@ -297,6 +297,8 @@ public class Quest {
 
         if (toEnable) {
             QuestRegistry.getInstance().submit(this); // resubmit previously untoggled
+        } else {
+            QuestRegistry.getInstance().remove(this, true); // remove from world (but preserve)
         }
 
         Database.getInstance().setQuestToggled( // update database state (when we can)

--- a/src/main/java/playerquests/product/Quest.java
+++ b/src/main/java/playerquests/product/Quest.java
@@ -24,11 +24,13 @@ import playerquests.builder.quest.action.QuestAction;
 import playerquests.builder.quest.npc.QuestNPC; // quest npc builder
 import playerquests.builder.quest.stage.QuestStage; // quest stage builder
 import playerquests.utility.ChatUtils; // helpers for in-game chat
+import playerquests.utility.ChatUtils.MessageBuilder;
+import playerquests.utility.ChatUtils.MessageStyle;
+import playerquests.utility.ChatUtils.MessageTarget;
 import playerquests.utility.ChatUtils.MessageType;
 import playerquests.utility.FileUtils; // helpers for working with files
 import playerquests.utility.annotation.Key; // key-value pair annotations for KeyHandler
 import playerquests.utility.singleton.Database;
-import playerquests.utility.singleton.QuestRegistry;
 
 /**
  * The Quest product containing all the information 
@@ -63,6 +65,12 @@ public class Quest {
      * The UUID of the player who created this quest.
      */
     private UUID creator = null;
+
+    @JsonIgnore
+    /**
+     * If the quest is toggled.
+     */
+    private Boolean toggled = false;
     
     /**
      * Creates a quest instance for playing and viewing!
@@ -105,6 +113,9 @@ public class Quest {
                 npc.setQuest(this);
             }
         }
+
+        // Determine if toggled
+        this.toggled = Database.getInstance().getQuestToggled(this);
     }
 
     /**
@@ -214,28 +225,27 @@ public class Quest {
      */
     @Key("quest")
     public String save() {
+        String questName = "quest/templates/" + this.getID() + ".json"; // name pattern
+
+        // create quest in fs, or update it
         try {
+            if (FileUtils.check(questName)) { // if the quest is in the fs
+                Core.getQuestRegistry().submit(this);
+            }
+
             FileUtils.create( // create the template json file
-                "quest/templates/" + this.getID() + ".json", // name pattern
+                questName, // name pattern
                 this.toTemplateString().getBytes() // put the content in the file
             );
+            return "'" + this.title + "' was saved.";
         } catch (IOException e) {
             ChatUtils.message(e.getMessage())
                 .player(Bukkit.getPlayer(this.creator))
                 .type(MessageType.ERROR)
                 .send();
             System.err.println(e);
-            return "Quest Builder: '" + this.title + "' could not save.";
+            return "'" + this.title + "' could not save.";
         }
-
-        // remove before re-submitting, to remove from world and quest diaries
-        QuestRegistry questRegistry = Core.getQuestRegistry();
-        if (questRegistry.getAllQuests().containsValue(this)) {
-            questRegistry.remove(questRegistry.getQuest(this.getID()));
-        }
-
-        // NOTE: submission is done by fs watcher in ServerListener
-        return "Quest Builder: '" + this.title + "' was saved";
     }
 
     @JsonIgnore
@@ -255,18 +265,16 @@ public class Quest {
      * Checks if the quest is toggled/enabled.
      * @return whether the quest is enabled/being shown
      */
-    public boolean isToggled() {
-        return Database.getQuestToggled(this);
+    @JsonIgnore
+    public Boolean isToggled() {
+        return Database.getInstance().getQuestToggled(this);
     }
 
     /**
      * Toggle function as a switch.
      */
     public void toggle() {
-        Database.setQuestToggled(
-            this,
-            !Database.getQuestToggled(this)
-        );
+        this.toggle(!this.toggled);
     }
 
     /**
@@ -274,45 +282,53 @@ public class Quest {
      * @param toEnable whether to show/enable the quest
      */
     public void toggle(boolean toEnable) {
-        Database.setQuestToggled(this, toEnable);
+        this.toggled = toEnable;
+
+        Database.getInstance().setQuestToggled( // update database state (when we can)
+            this,
+            toEnable
+        );
     }
 
-    public Boolean isValid() {
-        UUID uuid = this.creator;
-        Player player = uuid != null ? Bukkit.getPlayer(uuid) : null; // the player to send invalid npc messages to
+    @JsonIgnore
+    public boolean isValid() {
+        UUID questCreator = this.creator;
+        Player player = null;
+        MessageBuilder response = new MessageBuilder("Something is wrong with the quest") // default message; default sends to console
+            .type(MessageType.ERROR)
+            .target(MessageTarget.CONSOLE)
+            .style(MessageStyle.PLAIN);
+        boolean isValid = true; // assume valid unless errors are found
 
-        if (uuid != null && player == null) {
-            return false;
+        // Check if the player is valid and set the player object if a creator is present
+        if (questCreator != null) {
+            player = Bukkit.getPlayer(questCreator); // get player from UUID
+            response.player(player).style(MessageStyle.PRETTY); // set message target to player if player is found
         }
 
-        if (uuid == null) { // universal quests exist, so not having a player cannot be a failure
-            return true;
-        }
-
+        // Validate quest title
         if (this.title == null) {
-            ChatUtils.message("A quest has no title")
-                .player(player)
-                .type(MessageType.ERROR)
-                .send();
-            return false;
+            response.content("A quest has no title");
+            isValid = false;
         }
 
+        // Validate quest entry
         if (this.entry == null) {
-            ChatUtils.message(String.format("The %s quest has no starting point", this.title))
-                .player(player)
-                .type(MessageType.ERROR)
-                .send();
-            return false;
-        } else {
-            if (this.stages == null || this.stages.isEmpty()) {
-                ChatUtils.message(String.format("The %s quest has no stages", this.title))
-                    .player(player)
-                    .type(MessageType.ERROR)
-                    .send();
-                return false;
-            }
+            response.content(String.format("The %s quest has no starting point", this.title));
+            isValid = false;
         }
 
-        return true;
+        // Validate quest stages
+        if (this.stages == null || this.stages.isEmpty()) {
+            response.content(String.format("The %s quest has no stages", this.title));
+            isValid = false;
+        }
+
+        // send the response
+        if (!isValid) {
+            response.send(); // send our :( message
+        }
+
+        return isValid;
     }
 }

--- a/src/main/java/playerquests/product/Quest.java
+++ b/src/main/java/playerquests/product/Quest.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.SerializationFeature; // used to configure
 
 import playerquests.Core; // the main class of this plugin
 import playerquests.builder.quest.action.QuestAction;
+import playerquests.builder.quest.data.ConnectionsData;
 import playerquests.builder.quest.npc.QuestNPC; // quest npc builder
 import playerquests.builder.quest.stage.QuestStage; // quest stage builder
 import playerquests.utility.ChatUtils; // helpers for in-game chat
@@ -150,6 +151,15 @@ public class Quest {
      */
     public String getTitle() {
         return title;
+    }
+
+    /**
+     * Get the starting prev, current, next steps.
+     * @return
+     */
+    @JsonIgnore
+    public ConnectionsData getConnections() {
+        return new ConnectionsData(null, this.entry, null);
     }
 
     /**

--- a/src/main/java/playerquests/product/Quest.java
+++ b/src/main/java/playerquests/product/Quest.java
@@ -234,8 +234,7 @@ public class Quest {
             questRegistry.remove(questRegistry.getQuest(this.getID()));
         }
 
-        // asume enabled and submit (adds the quest to the world)
-        questRegistry.submit(this);
+        // NOTE: submission is done by fs watcher in ServerListener
         return "Quest Builder: '" + this.title + "' was saved";
     }
 

--- a/src/main/java/playerquests/product/Quest.java
+++ b/src/main/java/playerquests/product/Quest.java
@@ -68,7 +68,6 @@ public class Quest {
      */
     private UUID creator = null;
 
-    @JsonIgnore
     /**
      * If the quest is toggled.
      */
@@ -87,7 +86,8 @@ public class Quest {
         @JsonProperty("entry") QuestStage entry, 
         @JsonProperty("npcs") Map<String, QuestNPC> npcs, 
         @JsonProperty("stages") Map<String, QuestStage> stages, 
-        @JsonProperty("creator") UUID creator
+        @JsonProperty("creator") UUID creator,
+        @JsonProperty("toggled") Boolean toggled
     ) {
         // adding to key-value pattern handler
         Core.getKeyHandler().registerInstance(this);
@@ -102,6 +102,11 @@ public class Quest {
         this.stages = stages;
         this.creator = creator;
 
+        // determine if should be toggled
+        if (toggled != null) {
+            this.toggled = toggled;
+        }
+
         // Set Quest dependency for each QuestStage instead of custom deserialize
         if (stages != null) {
             for (QuestStage stage : stages.values()) {
@@ -115,9 +120,6 @@ public class Quest {
                 npc.setQuest(this);
             }
         }
-
-        // Determine if toggled
-        this.toggled = Database.getInstance().getQuestToggled(this);
     }
 
     /**

--- a/src/main/java/playerquests/product/Quest.java
+++ b/src/main/java/playerquests/product/Quest.java
@@ -32,6 +32,7 @@ import playerquests.utility.ChatUtils.MessageType;
 import playerquests.utility.FileUtils; // helpers for working with files
 import playerquests.utility.annotation.Key; // key-value pair annotations for KeyHandler
 import playerquests.utility.singleton.Database;
+import playerquests.utility.singleton.QuestRegistry;
 
 /**
  * The Quest product containing all the information 
@@ -293,6 +294,10 @@ public class Quest {
      */
     public void toggle(boolean toEnable) {
         this.toggled = toEnable;
+
+        if (toEnable) {
+            QuestRegistry.getInstance().submit(this); // resubmit previously untoggled
+        }
 
         Database.getInstance().setQuestToggled( // update database state (when we can)
             this,

--- a/src/main/java/playerquests/product/Quest.java
+++ b/src/main/java/playerquests/product/Quest.java
@@ -356,4 +356,23 @@ public class Quest {
     public String toString() {
         return String.format("%s=%s", super.toString(), this.getID());
     }
+
+    public void refund() {
+        if (this.creator == null) {
+            return; // no need to refund, a shared quest has infinite resources
+        }
+
+        Player player = Bukkit.getPlayer(creator);
+
+        // return NPC resources
+        this.getNPCs().values().stream().forEach(npc -> {
+            npc.refund(player);
+        });
+
+        // let the player know
+        ChatUtils.message("Returned items from quest.")
+            .player(player)
+            .style(MessageStyle.PRETTY)
+            .send();
+    }
 }

--- a/src/main/java/playerquests/product/Quest.java
+++ b/src/main/java/playerquests/product/Quest.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.SerializationFeature; // used to configure
 import playerquests.Core; // the main class of this plugin
 import playerquests.builder.quest.action.QuestAction;
 import playerquests.builder.quest.data.ConnectionsData;
+import playerquests.builder.quest.data.StagePath;
 import playerquests.builder.quest.npc.QuestNPC; // quest npc builder
 import playerquests.builder.quest.stage.QuestStage; // quest stage builder
 import playerquests.utility.ChatUtils; // helpers for in-game chat
@@ -49,7 +50,7 @@ public class Quest {
     /**
      * The starting/entry point stage ID for this quest.
      */
-    private String entry = null;
+    private StagePath entry = null;
 
     /**
      * The map of NPCs used in this quest, by their ID.
@@ -83,7 +84,7 @@ public class Quest {
      */
     public Quest(
         @JsonProperty("title") String title, 
-        @JsonProperty("entry") QuestStage entry, 
+        @JsonProperty("entry") StagePath entry, 
         @JsonProperty("npcs") Map<String, QuestNPC> npcs, 
         @JsonProperty("stages") Map<String, QuestStage> stages, 
         @JsonProperty("creator") UUID creator,
@@ -95,7 +96,7 @@ public class Quest {
         this.title = title;
         
         if (entry != null) {
-            this.entry = entry.getID();
+            this.entry = entry;
         }
 
         this.npcs = npcs;
@@ -140,9 +141,9 @@ public class Quest {
         try {
             quest = jsonObjectMapper.readValue(questTemplate, Quest.class);
         } catch (JsonMappingException e) {
-            System.err.println("Could not map a quest template string to a valid quest product.");
+            System.err.println("Could not map a quest template string to a valid quest product. " + e);
         } catch (JsonProcessingException e) {
-            System.err.println("Malformed JSON attempted as a quest template string.");
+            System.err.println("Malformed JSON attempted as a quest template string. " + e);
         }
 
         return quest;
@@ -169,7 +170,7 @@ public class Quest {
      * Gets the starting/entry point stage ID for this quest.
      * @return the ID of the starting/entry point stage for this quest
      */
-    public String getEntry() {
+    public StagePath getEntry() {
         return entry;
     }
 

--- a/src/main/java/playerquests/product/Quest.java
+++ b/src/main/java/playerquests/product/Quest.java
@@ -31,8 +31,8 @@ import playerquests.utility.ChatUtils.MessageTarget;
 import playerquests.utility.ChatUtils.MessageType;
 import playerquests.utility.FileUtils; // helpers for working with files
 import playerquests.utility.annotation.Key; // key-value pair annotations for KeyHandler
-import playerquests.utility.singleton.Database;
-import playerquests.utility.singleton.QuestRegistry;
+import playerquests.utility.singleton.Database; // the preservation everything store
+import playerquests.utility.singleton.QuestRegistry; // multi-threaded quest store
 
 /**
  * The Quest product containing all the information 

--- a/src/main/java/playerquests/utility/ChatUtils.java
+++ b/src/main/java/playerquests/utility/ChatUtils.java
@@ -125,6 +125,15 @@ public class ChatUtils {
         }
 
         /**
+         * For editing the base message.
+         * @param the potatos of what the message is
+         */
+        public MessageBuilder content(String baseMessage) {
+            this.content = baseMessage;
+            return this;
+        }
+
+        /**
          * For adding a message type
          * @param messageType the MessageType enum
          * @return the MessageBuilder to chain next function.

--- a/src/main/java/playerquests/utility/FileUtils.java
+++ b/src/main/java/playerquests/utility/FileUtils.java
@@ -64,4 +64,16 @@ public class FileUtils {
             throw new IOException("Could not delete the '" + filename + "' file.", e);
         }
     }
+
+    /**
+     * Checks if a file at the specified path exists.
+     * @param filename relative child path + filename
+     * @throws IOException when the file cannot be read
+     * @return if the file exists
+     */
+    public static Boolean check(String filename) throws IOException {
+        Path fullPath = Paths.get(Core.getPlugin().getDataFolder() + "/" + filename);
+
+        return Files.exists(fullPath);
+    }
 }

--- a/src/main/java/playerquests/utility/MigrationUtils.java
+++ b/src/main/java/playerquests/utility/MigrationUtils.java
@@ -1,0 +1,93 @@
+package playerquests.utility;
+
+/**
+ * Provides the changes for each version.
+ * For example: the changes to the database.
+ */
+public class MigrationUtils {
+    // Get migration query for version 0.4
+    public static String dbV0_4() {
+        return "ALTER TABLE quests ADD COLUMN toggled TEXT DEFAULT true;";
+    }
+
+    // Get migration query for version 0.5
+    public static String dbV0_5() {
+        throw new IllegalArgumentException("No migration query for version v0.5.1");
+    }
+
+    // Get migration query for version 0.5.1
+    public static String dbV0_5_1() {
+        return """
+            -- Begin a transaction to ensure all operations are atomic
+            BEGIN TRANSACTION;
+            
+            -- Drop temporary tables if they exist
+            DROP TABLE IF EXISTS temp_diary_quests;
+            DROP TABLE IF EXISTS temp_diaries;
+            DROP TABLE IF EXISTS temp_quests;
+            DROP TABLE IF EXISTS temp_players;
+            
+            -- Create temporary tables for migration
+            CREATE TABLE temp_players (
+                uuid TEXT PRIMARY KEY NOT NULL
+            );
+            
+            CREATE TABLE temp_quests (
+                id TEXT PRIMARY KEY NOT NULL
+            );
+            
+            CREATE TABLE temp_diaries (
+                id TEXT PRIMARY KEY NOT NULL,
+                player TEXT UNIQUE,
+                FOREIGN KEY (player) REFERENCES temp_players(uuid)
+            );
+            
+            CREATE TABLE temp_diary_quests (
+                id TEXT PRIMARY KEY NOT NULL,
+                stage TEXT NOT NULL,
+                action TEXT,
+                quest TEXT,
+                diary TEXT,
+                FOREIGN KEY (quest) REFERENCES temp_quests(id),
+                FOREIGN KEY (diary) REFERENCES temp_diaries(id)
+            );
+            
+            -- Migrate data from old tables to temporary tables
+            INSERT INTO temp_players (uuid)
+            SELECT uuid FROM players;
+            
+            INSERT INTO temp_quests (id)
+            SELECT id FROM quests;
+            
+            INSERT INTO temp_diaries (id, player)
+            SELECT 'diary_' || p.uuid, p.uuid
+            FROM diaries AS d
+            JOIN players AS p ON d.player = p.id;
+            
+            INSERT INTO temp_diary_quests (id, stage, action, quest, diary)
+            SELECT dq.id, dq.stage, dq.action, dq.quest, 'diary_' || p.uuid
+            FROM diary_quests AS dq
+            JOIN diaries AS d ON dq.diary = d.id
+            JOIN players AS p ON d.player = p.id;
+            
+            -- Drop old tables
+            DROP TABLE IF EXISTS diary_quests;
+            DROP TABLE IF EXISTS diaries;
+            DROP TABLE IF EXISTS quests;
+            DROP TABLE IF EXISTS players;
+            
+            -- Rename temporary tables to match new schema
+            ALTER TABLE temp_players RENAME TO players;
+            ALTER TABLE temp_quests RENAME TO quests;
+            ALTER TABLE temp_diaries RENAME TO diaries;
+            ALTER TABLE temp_diary_quests RENAME TO diary_quests;
+            
+            -- Remove unused sequence tracking (next increments)
+            DELETE FROM sqlite_sequence WHERE name = 'diaries';
+            DELETE FROM sqlite_sequence WHERE name = 'players';
+            
+            -- Commit the transaction if everything is successful
+            COMMIT;
+        """;
+    }
+}

--- a/src/main/java/playerquests/utility/listener/BlockListener.java
+++ b/src/main/java/playerquests/utility/listener/BlockListener.java
@@ -112,17 +112,22 @@ public class BlockListener implements Listener {
 
     public void remove(Quest quest) {
         BlockData replacementBlock = Material.AIR.createBlockData();
-        this.activeBlockNPCs.entrySet().stream()
-            .filter(e -> e.getValue().getNPC().getQuest().getID().equals(quest.getID()))
-            .forEach(entry -> {
-                Location npcLocation = entry.getKey().getLocation();
-                World npcWorld = npcLocation.getWorld();
+        this.activeBlockNPCs.entrySet().removeIf(entry -> {
+            if (!entry.getValue().getNPC().getQuest().getID().equals(quest.getID())) {
+                return false; // keep entry that doesn't match quest removal
+            }
 
-                // replace the NPC block
-                npcWorld.setBlockData(
-                    npcLocation, 
-                    replacementBlock
-                );
-            });
+            Location npcLocation = entry.getKey().getLocation();
+            World npcWorld = npcLocation.getWorld();
+    
+            // replace the NPC block
+            npcWorld.setBlockData(
+                npcLocation, 
+                replacementBlock
+            );
+    
+            // remove the 'active npc'
+            return true;
+        });
     }
 }

--- a/src/main/java/playerquests/utility/listener/BlockListener.java
+++ b/src/main/java/playerquests/utility/listener/BlockListener.java
@@ -71,7 +71,7 @@ public class BlockListener implements Listener {
         activeBlockNPCs = filteredBlockNPCs;
 
         // remove the quest, as now it's missing the NPC
-        QuestRegistry.getInstance().remove(quest);
+        QuestRegistry.getInstance().remove(quest, true);
     }
     
     @EventHandler
@@ -102,6 +102,9 @@ public class BlockListener implements Listener {
         if (!this.activeBlockNPCs.containsKey(brokenBlock)) {
             return; // don't continue if not an NPC block
         }
+
+        event.setCancelled(true); // don't drop the block (block duplication)
+        brokenBlock.getWorld().setBlockData(brokenBlock.getLocation(), Material.AIR.createBlockData()); // replace the block with air
 
         BlockNPC npc = this.activeBlockNPCs.get(brokenBlock);
         this.unregisterBlockNPC(npc);

--- a/src/main/java/playerquests/utility/listener/ServerListener.java
+++ b/src/main/java/playerquests/utility/listener/ServerListener.java
@@ -55,6 +55,12 @@ public class ServerListener implements Listener {
                 .send();
         }
 
+        // create templates folder if it doesn't exist
+        f = new File(Core.getPlugin().getDataFolder() + "/quest/templates");
+        if (!f.exists()) {
+            f.mkdirs();
+        }
+
         // Save the demo quest to the server
         Core.getPlugin().saveResource("quest/templates/beans-tester-bonus.json", true);
 

--- a/src/main/java/playerquests/utility/listener/ServerListener.java
+++ b/src/main/java/playerquests/utility/listener/ServerListener.java
@@ -151,10 +151,7 @@ public class ServerListener implements Listener {
                 .send();
         }
 
-        // Ensure quest submission runs on the main thread
-        Bukkit.getScheduler().runTask(Core.getPlugin(), () -> {
-            submitQuestsToRegistry(allQuests);
-        });
+        submitQuestsToRegistry(allQuests);
     }
 
     private String getQuestName(Path path) {

--- a/src/main/java/playerquests/utility/listener/ServerListener.java
+++ b/src/main/java/playerquests/utility/listener/ServerListener.java
@@ -67,6 +67,7 @@ public class ServerListener implements Listener {
         // initialise the database
         Database.getInstance().init();
 
+        // cancel ongoing tasks if is a reload (handle reloading)
         if (event.getEventName().equals("RELOAD")) {
             Bukkit.getServer().getScheduler().cancelTasks(Core.getPlugin());
             QuestRegistry.getInstance().clear();

--- a/src/main/java/playerquests/utility/listener/ServerListener.java
+++ b/src/main/java/playerquests/utility/listener/ServerListener.java
@@ -1,85 +1,133 @@
 package playerquests.utility.listener;
 
 import java.io.File;
-import java.io.IOException; // thrown when a file operation fails, like reading
+import java.io.IOException; // Thrown when a file operation fails, such as reading
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import org.bukkit.Bukkit; // bukkit API
-import org.bukkit.event.EventHandler; // indicate that a method is wanting to handle an event
-import org.bukkit.event.Listener; // registering listening to Bukkit in-game events
-import org.bukkit.event.server.ServerLoadEvent; // when a server is reloaded or started up
+import org.bukkit.Bukkit; // Bukkit API for interacting with the server
+import org.bukkit.event.EventHandler; // Annotation to mark methods as event handlers
+import org.bukkit.event.Listener; // Interface for registering event listeners
+import org.bukkit.event.server.ServerLoadEvent; // Event triggered when the server is loaded or reloaded
 
-import com.fasterxml.jackson.core.JsonProcessingException; // thrown when json cannot be processed
-import com.fasterxml.jackson.databind.JsonMappingException; // thrown when json is malformed
+import com.fasterxml.jackson.core.JsonProcessingException; // Thrown when JSON cannot be processed
+import com.fasterxml.jackson.databind.JsonMappingException; // Thrown when JSON is malformed
 
-import playerquests.Core; // accessing plugin singeltons
-import playerquests.client.quest.QuestClient; // represents a quest player/quest tracking
-import playerquests.product.Quest; // quest product class
-import playerquests.utility.ChatUtils; // for sending cute-ified messages
+import playerquests.Core; // Access to plugin singleton
+import playerquests.client.quest.QuestClient; // Represents a quest client for player quest tracking
+import playerquests.product.Quest; // Represents a quest product class
+import playerquests.utility.ChatUtils; // Utility for sending chat messages
 import playerquests.utility.ChatUtils.MessageStyle;
 import playerquests.utility.ChatUtils.MessageTarget;
 import playerquests.utility.ChatUtils.MessageType;
-import playerquests.utility.FileUtils; // helpers for working with files
-import playerquests.utility.singleton.Database; // API for game persistent data
-import playerquests.utility.singleton.QuestRegistry; // place where quests are stored
+import playerquests.utility.FileUtils; // Utility for file operations
+import playerquests.utility.singleton.Database; // API for managing persistent game data
+import playerquests.utility.singleton.QuestRegistry; // Registry for storing quests
 
 /**
- * Listens out for all server-related events to inform 
- * where needed.
+ * This class listens for server-related events, such as server load or reload,
+ * and performs necessary actions such as initializing data and processing quests.
  */
 public class ServerListener implements Listener {
 
+    /**
+     * Constructor for the ServerListener class. Registers this listener
+     * with the Bukkit event system.
+     */
     public ServerListener() {
         Bukkit.getPluginManager().registerEvents(this, Core.getPlugin());
     }
 
     /**
-     * Ran whenever the server is started or reloaded.
-     * Use [return value].onFinish(() -> {}) for callback.
-     * @param event the LoadType
-     * @return the ServerListener itself
+     * Handles the ServerLoadEvent, which is triggered when the server is
+     * started or reloaded. Initializes necessary directories, processes quest
+     * templates, and sets up quest clients for online players.
+     * 
+     * @param event the ServerLoadEvent that contains information about the server load
+     * @return the ServerListener instance
      */
     @EventHandler
     public ServerListener onLoad(ServerLoadEvent event) {
-        // create plugin folder if it doesn't exist
-        File f = new File(Core.getPlugin().getDataFolder() + "/");
-        if (!f.exists()) {
-            f.mkdir();
-            ChatUtils.message("Welcome!")
-                .target(MessageTarget.WORLD)
-                .type(MessageType.NOTIF)
-                .send();
+        createDirectories();
+        initializeDatabase();
+
+        if (isServerReload(event)) {
+            handleServerReload();
         }
 
-        // create templates folder if it doesn't exist
-        f = new File(Core.getPlugin().getDataFolder() + "/quest/templates");
-        if (!f.exists()) {
-            f.mkdirs();
+        processQuests();
+        createQuestClients();
+
+        return this;
+    }
+
+    /**
+     * Creates necessary directories for the plugin if they do not already exist.
+     */
+    private void createDirectories() {
+        File dataFolder = new File(Core.getPlugin().getDataFolder() + "/");
+        if (!dataFolder.exists()) {
+            dataFolder.mkdir();
+            sendWelcomeMessage();
         }
 
-        // Save the demo quest to the server
+        File templatesFolder = new File(Core.getPlugin().getDataFolder() + "/quest/templates");
+        if (!templatesFolder.exists()) {
+            templatesFolder.mkdirs();
+        }
+
         Core.getPlugin().saveResource("quest/templates/beans-tester-bonus.json", true);
+    }
 
-        // initialise the database
+    /**
+     * Sends a welcome message to the world when the plugin folder is created.
+     */
+    private void sendWelcomeMessage() {
+        ChatUtils.message("Welcome!")
+            .target(MessageTarget.WORLD)
+            .type(MessageType.NOTIF)
+            .send();
+    }
+
+    /**
+     * Initializes the database and handles any necessary setup.
+     */
+    private void initializeDatabase() {
         Database.getInstance().init();
+    }
 
-        // cancel ongoing tasks if is a reload (handle reloading)
-        if (event.getEventName().equals("RELOAD")) {
-            Bukkit.getServer().getScheduler().cancelTasks(Core.getPlugin());
-            QuestRegistry.getInstance().clear();
-        }
+    /**
+     * Determines if the event represents a server reload.
+     * 
+     * @param event the ServerLoadEvent
+     * @return true if the event represents a server reload, false otherwise
+     */
+    private boolean isServerReload(ServerLoadEvent event) {
+        return "RELOAD".equals(event.getEventName());
+    }
 
-        // find all quests
-        File fsQuestsDir = new File(Core.getPlugin().getDataFolder(), "/quest/templates");
-        Set<String> allQuests = new HashSet<String>(); // CREATE MAIN LIST
-        allQuests.addAll(Database.getInstance().getAllQuests()); // ADD DB QUESTS
-        try (Stream<Path> paths = Files.walk(fsQuestsDir.toPath())) { // ADD FILESYTEM QUESTS
-            paths.filter(Files::isRegularFile)  // no dirs, only files
-                .filter(path -> path.toString().endsWith(".json"))  // only json files
+    /**
+     * Handles the server reload by canceling ongoing tasks and clearing the quest registry.
+     */
+    private void handleServerReload() {
+        Bukkit.getServer().getScheduler().cancelTasks(Core.getPlugin());
+        QuestRegistry.getInstance().clear();
+    }
+
+    /**
+     * Processes quests from both the database and file system, and submits them to the quest registry.
+     */
+    private void processQuests() {
+        File questsDir = new File(Core.getPlugin().getDataFolder(), "/quest/templates");
+        Set<String> allQuests = new HashSet<>();
+        allQuests.addAll(Database.getInstance().getAllQuests());
+
+        try (Stream<Path> paths = Files.walk(questsDir.toPath())) {
+            paths.filter(Files::isRegularFile)  // Filter to include only files
+                .filter(path -> path.toString().endsWith(".json"))  // Include only JSON files
                 .forEach(path -> {
                     String questName = path.toString()
                         .replace(".json", "")
@@ -94,9 +142,17 @@ public class ServerListener implements Listener {
                 .send();
         }
 
-        // try to submit found quests to quest registry
-        allQuests.forEach(id -> {
-            Boolean err = true; // assume errored (avoids repeating it for each catch)
+        submitQuestsToRegistry(allQuests);
+    }
+
+    /**
+     * Submits quests to the quest registry and handles any errors.
+     * 
+     * @param quests the set of quest IDs to process
+     */
+    private void submitQuestsToRegistry(Set<String> quests) {
+        quests.forEach(id -> {
+            boolean errorOccurred = true; // Assume an error occurred initially
             
             try {
                 Quest newQuest = Quest.fromTemplateString(FileUtils.get("quest/templates/" + id + ".json"));
@@ -106,39 +162,39 @@ public class ServerListener implements Listener {
                 }
 
                 QuestRegistry.getInstance().submit(newQuest);
-                err = false;
+                errorOccurred = false;
 
             } catch (JsonMappingException e) {
-                System.err.println("Could not accurately map template: " + id + ", to the Quest object. " + e);
+                System.err.println("Could not map template: " + id + " to the Quest object. " + e);
             } catch (JsonProcessingException e) {
-                System.err.println("JSON in template: " + id + ", is malformed. " + e);
+                System.err.println("JSON in template: " + id + " is malformed. " + e);
             } catch (IOException e) {
                 System.err.println("Could not read file: " + id + ".json. " + e);
             }
 
-            // remove the quest if unreadable
-            if (err) {
+            // Remove the quest from the database if an error occurred
+            if (errorOccurred) {
                 Database.removeQuest(id);
             }
         });
 
         System.out.println("[PlayerQuests] Finished loading database quests into registry: " + QuestRegistry.getInstance().getAllQuests().keySet());
-
-        // for every user, create a quest client and add it to registry.
-        // this enables a player to interact with and track quests.
-        Bukkit.getServer().getOnlinePlayers().stream()
-            .forEach(player -> {
-                QuestClient quester = new QuestClient(player);
-                QuestRegistry.getInstance().addQuester(quester);
-            });
-
-        // function chaining reasons:
-        return this;
     }
 
     /**
-     * Sets code to be executed when the function is finished.
-     * @param runnable the code to run when the function completes
+     * Creates a quest client for each online player and adds it to the quest registry.
+     */
+    private void createQuestClients() {
+        Bukkit.getServer().getOnlinePlayers().forEach(player -> {
+            QuestClient quester = new QuestClient(player);
+            QuestRegistry.getInstance().addQuester(quester);
+        });
+    }
+
+    /**
+     * Executes the provided runnable code when the function completes.
+     * 
+     * @param runnable the code to execute upon completion
      */
     public void onFinish(Runnable runnable) {
         if (runnable != null) {

--- a/src/main/java/playerquests/utility/listener/ServerListener.java
+++ b/src/main/java/playerquests/utility/listener/ServerListener.java
@@ -131,8 +131,11 @@ public class ServerListener implements Listener {
     private void processQuests() {
         File questsDir = new File(Core.getPlugin().getDataFolder(), "/quest/templates");
         Set<String> allQuests = new HashSet<>();
+        
+        // add from db
         allQuests.addAll(Database.getInstance().getAllQuests());
 
+        // add from fs
         try (Stream<Path> paths = Files.walk(questsDir.toPath())) {
             paths.filter(Files::isRegularFile) // Filter to include only files
                 .filter(path -> path.toString().endsWith(".json")) // Include only JSON files
@@ -195,11 +198,15 @@ public class ServerListener implements Listener {
 
             // Remove the quest from the database if an error occurred
             if (errorOccurred) {
-                Database.removeQuest(id);
+                Database.getInstance().removeQuest(id);
             }
         });
 
-        System.out.println("[PlayerQuests] Finished loading database quests into registry: " + quests);
+        ChatUtils.message("Finished loading database quests into registry: " + quests)
+            .target(MessageTarget.CONSOLE)
+            .style(MessageStyle.PLAIN)
+            .type(MessageType.NOTIF)
+            .send();
     }
 
     /**

--- a/src/main/java/playerquests/utility/listener/ServerListener.java
+++ b/src/main/java/playerquests/utility/listener/ServerListener.java
@@ -24,6 +24,7 @@ import playerquests.utility.ChatUtils.MessageTarget; // Enum for different messa
 import playerquests.utility.ChatUtils.MessageType; // Enum for different message types
 import playerquests.utility.FileUtils; // Utility for file operations
 import playerquests.utility.singleton.Database; // API for managing persistent game data
+import playerquests.utility.singleton.PlayerQuests;
 import playerquests.utility.singleton.QuestRegistry; // Registry for storing quests
 
 /**
@@ -77,17 +78,14 @@ public class ServerListener implements Listener {
         // Cancel all tasks scheduled by this plugin to prevent overlaps
         Bukkit.getServer().getScheduler().cancelTasks(Core.getPlugin());
 
-        // Clear the QuestRegistry to ensure no quests are left 
-        // in memory or are in an inconsistent state after the plugin
-        // is disabled. This is for maintaining the integrity 
-        // of the quest data and preventing memory leaks.
-        QuestRegistry.getInstance().clear();
+        // Close/clear the plugin
+        PlayerQuests.getInstance().clear();
 
         // Stop the WatchService used for monitoring file changes.
         // This ensures that no further file watching occurs after 
         // the plugin is disabled, and resources related to file 
         // monitoring are properly released.
-        stopWatchService();
+        stopWatchService();        
     }
 
     /**

--- a/src/main/java/playerquests/utility/listener/ServerListener.java
+++ b/src/main/java/playerquests/utility/listener/ServerListener.java
@@ -20,6 +20,7 @@ import playerquests.Core; // accessing plugin singeltons
 import playerquests.client.quest.QuestClient; // represents a quest player/quest tracking
 import playerquests.product.Quest; // quest product class
 import playerquests.utility.ChatUtils; // for sending cute-ified messages
+import playerquests.utility.ChatUtils.MessageStyle;
 import playerquests.utility.ChatUtils.MessageTarget;
 import playerquests.utility.ChatUtils.MessageType;
 import playerquests.utility.FileUtils; // helpers for working with files
@@ -79,8 +80,11 @@ public class ServerListener implements Listener {
                     allQuests.add(questName);
                 });
         } catch (IOException e) {
-            System.err.println("Error processing file paths");
-            e.printStackTrace();
+            ChatUtils.message("Could not process the quests template directory/path :(. " + e)
+                .target(MessageTarget.CONSOLE)
+                .style(MessageStyle.PLAIN)
+                .type(MessageType.ERROR)
+                .send();
         }
 
         // try to submit found quests to quest registry

--- a/src/main/java/playerquests/utility/singleton/Database.java
+++ b/src/main/java/playerquests/utility/singleton/Database.java
@@ -429,11 +429,6 @@ public class Database {
             preparedStatement.execute();
             connection.close();
             
-            if (state) {
-                QuestRegistry.getInstance().submit(quest);
-            } else {
-                QuestRegistry.getInstance().remove(quest, true);
-            }
         } catch (SQLException e) {
             System.err.println("Could not toggle the quest " + quest.toString() + ". " + e.getMessage());
         }

--- a/src/main/java/playerquests/utility/singleton/Database.java
+++ b/src/main/java/playerquests/utility/singleton/Database.java
@@ -323,6 +323,8 @@ public class Database {
                 ids.add(result.getString("id"));
             }
 
+            getConnection().close();
+
             return ids;
             
         } catch (SQLException e) {

--- a/src/main/java/playerquests/utility/singleton/PlayerQuests.java
+++ b/src/main/java/playerquests/utility/singleton/PlayerQuests.java
@@ -1,11 +1,15 @@
 package playerquests.utility.singleton;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.bukkit.Location; // the minecraft location object
 import org.bukkit.World; // the minecraft world
 import org.bukkit.block.Block; // the minecraft block
 
 import playerquests.builder.quest.npc.BlockNPC; // a block representing an NPC
 import playerquests.builder.quest.npc.QuestNPC; // core NPC object/data
+import playerquests.client.Director; // generic director type
 import playerquests.product.Quest; // represents a quest product
 import playerquests.utility.listener.BlockListener; // for block-related events
 import playerquests.utility.listener.PlayerListener; // for player-related events
@@ -64,6 +68,11 @@ public class PlayerQuests {
     }
 
     /**
+     * List of directors.
+     */
+    private List<Director> directors = new ArrayList<Director>();
+
+    /**
      * Puts the block in the world and registers
      * it as an NPC.
      * @param blockNPC the block details of an npc
@@ -101,5 +110,24 @@ public class PlayerQuests {
         // remove all NPCs
         blockListener.remove(quest);
     }
-    
+
+    public void addDirector(Director director) {
+        this.directors.add(director);
+    }
+
+    /**
+     * Clear each part of the quest.
+     * 
+     * Clear the QuestRegistry to ensure no quests are left 
+     * in memory or are in an inconsistent state after the plugin
+     * is disabled. This is for maintaining the integrity 
+     * of the quest data and preventing memory leaks.
+     */
+    public void clear() {
+        QuestRegistry.getInstance().clear();
+        directors.removeIf(director -> {
+            director.close();  // Close the director
+            return true;       // Remove the entry
+        });
+    }
 }

--- a/src/main/java/playerquests/utility/singleton/QuestRegistry.java
+++ b/src/main/java/playerquests/utility/singleton/QuestRegistry.java
@@ -165,18 +165,21 @@ public class QuestRegistry {
         // remove ref from database
         if (!preserveInDatabase) {
             Database.removeQuest(quest.getID());
-        }
 
-        // remove ref from registry
-        registry.remove(quest.getID());
+            // remove ref from registry
+            registry.remove(quest.getID());
+
+            // remove traces from world
+            PlayerQuests.getInstance().remove(quest);
+
+            // untoggle
+            quest.toggle(false);
+        }
 
         // remove ref from questers
         questers.values().stream().forEach(quester -> {
             quester.removeQuest(quest);
         });
-
-        // remove traces from world
-        PlayerQuests.getInstance().remove(quest);
     }
 
     /**

--- a/src/main/java/playerquests/utility/singleton/QuestRegistry.java
+++ b/src/main/java/playerquests/utility/singleton/QuestRegistry.java
@@ -240,11 +240,6 @@ public class QuestRegistry {
      */
     public void addQuester(QuestClient quester) {
         questers.put(quester.getPlayer(), quester);
-        quester.addQuests(
-            this.registry.entrySet().stream()
-                .map(Map.Entry::getValue)
-                .collect(Collectors.toList())
-        );
     }
 
     /**

--- a/src/main/java/playerquests/utility/singleton/QuestRegistry.java
+++ b/src/main/java/playerquests/utility/singleton/QuestRegistry.java
@@ -1,13 +1,14 @@
 package playerquests.utility.singleton;
 
 import java.io.IOException;
+import java.util.Arrays; // generic array type
 import java.util.HashMap; // hash table map
-import java.util.List;
+import java.util.List; // generic list type
 import java.util.Map; // generic map type
-import java.util.Optional;
-import java.util.UUID;
+import java.util.Optional; // handling if a value may be null
+import java.util.UUID; // used for in-game player UUIDs
 import java.util.concurrent.atomic.AtomicBoolean; // modify boolean state in a stream operation
-import java.util.stream.Collectors;
+import java.util.stream.Collectors; // used to turn one type of list to another
 
 import org.bukkit.Bukkit; // accessing Bukkit API
 import org.bukkit.entity.HumanEntity; // representing players and other humanoid entities
@@ -82,7 +83,7 @@ public class QuestRegistry {
             });
 
         questers.values().stream().forEach(quester -> {
-            quester.update();
+            quester.addQuests(Arrays.asList(quest));
         });
     }
 
@@ -240,8 +241,12 @@ public class QuestRegistry {
      * @param quester a quest client
      */
     public void addQuester(QuestClient quester) {
-        questers.put(Bukkit.getPlayer(quester.getPlayer().getUniqueId()), quester);
-        quester.update(); // add quests from registry
+        questers.put(quester.getPlayer(), quester);
+        quester.addQuests(
+            this.registry.entrySet().stream()
+                .map(Map.Entry::getValue)
+                .collect(Collectors.toList())
+        );
     }
 
     /**

--- a/src/main/java/playerquests/utility/singleton/QuestRegistry.java
+++ b/src/main/java/playerquests/utility/singleton/QuestRegistry.java
@@ -79,6 +79,7 @@ public class QuestRegistry {
         quest.getNPCs().entrySet().stream()
             .forEach(entry -> {
                 QuestNPC npc = entry.getValue();
+                npc.setQuest(quest);
                 npc.place();
             });
 

--- a/src/main/java/playerquests/utility/singleton/QuestRegistry.java
+++ b/src/main/java/playerquests/utility/singleton/QuestRegistry.java
@@ -205,6 +205,9 @@ public class QuestRegistry {
             // remove from registry
             this.remove(quest);
 
+            // refund resources
+            quest.refund();
+
         } catch (IOException e) {
             MessageBuilder errorMessage = ChatUtils.message("Could not delete the " + quest.getTitle() + " quest. " + e)
                 .type(MessageType.ERROR)

--- a/src/main/java/playerquests/utility/singleton/QuestRegistry.java
+++ b/src/main/java/playerquests/utility/singleton/QuestRegistry.java
@@ -5,6 +5,7 @@ import java.util.HashMap; // hash table map
 import java.util.List;
 import java.util.Map; // generic map type
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean; // modify boolean state in a stream operation
 import java.util.stream.Collectors;
 
@@ -18,6 +19,9 @@ import playerquests.client.quest.QuestClient; // player quest state
 import playerquests.product.Quest; // describes quests
 import playerquests.utility.ChatUtils; // utility methods related to chat
 import playerquests.utility.FileUtils;
+import playerquests.utility.ChatUtils.MessageBuilder;
+import playerquests.utility.ChatUtils.MessageStyle;
+import playerquests.utility.ChatUtils.MessageTarget;
 import playerquests.utility.ChatUtils.MessageType;
 
 
@@ -188,6 +192,8 @@ public class QuestRegistry {
      * @return whether the operation was successful or not
      */
     public Boolean delete(Quest quest) {
+        UUID creator = quest.getCreator(); // get the creator if this quest has one
+
         // try to remove from files
         try {
             FileUtils.delete(this.questPath + "/" + quest.getID() + ".json");
@@ -196,10 +202,17 @@ public class QuestRegistry {
             this.remove(quest);
 
         } catch (IOException e) {
-            ChatUtils.message("Could not delete the " + quest.getTitle() + " quest")
-                .player(Bukkit.getPlayer(quest.getCreator()))
+            MessageBuilder errorMessage = ChatUtils.message("Could not delete the " + quest.getTitle() + " quest. " + e)
                 .type(MessageType.ERROR)
-                .send();
+                .target(MessageTarget.CONSOLE);
+
+            if (creator != null) { // send the error to the player if there is a creator UUID
+                errorMessage
+                    .player(Bukkit.getPlayer(creator))
+                    .style(MessageStyle.PRETTY);
+            }
+                
+            errorMessage.send();
             return false;
         }
 

--- a/src/main/java/playerquests/utility/singleton/QuestRegistry.java
+++ b/src/main/java/playerquests/utility/singleton/QuestRegistry.java
@@ -72,7 +72,7 @@ public class QuestRegistry {
         registry.put(quest.getID(), quest);
 
         // store ref to database
-        Database.addQuest(quest.getID());
+        Database.getInstance().addQuest(quest.getID());
 
         // place the NPCs in the world
         quest.getNPCs().entrySet().stream()
@@ -131,6 +131,11 @@ public class QuestRegistry {
 
         // do not continue if npc has no LocationData
         if (!isQuestValid.get()) {
+            ChatUtils.message("Invalid quest submitted: " + questID)
+                .target(MessageTarget.CONSOLE)
+                .style(MessageStyle.PLAIN)
+                .type(MessageType.ERROR)
+                .send();
             return;
         }
 
@@ -168,7 +173,7 @@ public class QuestRegistry {
     public void remove(Quest quest, Boolean preserveInDatabase) {
         // remove ref from database
         if (!preserveInDatabase) {
-            Database.removeQuest(quest.getID());
+            Database.getInstance().removeQuest(quest.getID());
 
             // remove ref from registry
             registry.remove(quest.getID());

--- a/src/main/java/playerquests/utility/singleton/QuestRegistry.java
+++ b/src/main/java/playerquests/utility/singleton/QuestRegistry.java
@@ -183,9 +183,6 @@ public class QuestRegistry {
         // remove traces from world
         PlayerQuests.getInstance().remove(quest);
 
-        // untoggle
-        quest.toggle(false);
-
         // remove ref from questers
         questers.values().stream().forEach(quester -> {
             quester.removeQuest(quest);

--- a/src/main/java/playerquests/utility/singleton/QuestRegistry.java
+++ b/src/main/java/playerquests/utility/singleton/QuestRegistry.java
@@ -176,15 +176,15 @@ public class QuestRegistry {
         if (!preserveInDatabase) {
             Database.getInstance().removeQuest(quest.getID());
 
-            // remove ref from registry
+            // remove ref from registry (needed when not preserved, otherwise editors cannot see their own quest)
             registry.remove(quest.getID());
-
-            // remove traces from world
-            PlayerQuests.getInstance().remove(quest);
-
-            // untoggle
-            quest.toggle(false);
         }
+
+        // remove traces from world
+        PlayerQuests.getInstance().remove(quest);
+
+        // untoggle
+        quest.toggle(false);
 
         // remove ref from questers
         questers.values().stream().forEach(quester -> {

--- a/src/main/java/playerquests/utility/singleton/QuestRegistry.java
+++ b/src/main/java/playerquests/utility/singleton/QuestRegistry.java
@@ -255,10 +255,22 @@ public class QuestRegistry {
      * @return the quest object
      */
     public Quest getQuest(String questID) {
+        return this.getQuest(questID, false);
+    }
+
+    /**
+     * Get a quest from the quest registry.
+     * If fails from quest registry, you can choose
+     * for it to search the questPath (resources folder).
+     * @param questID the quest ID
+     * @param searchFS whether to try searching the FS
+     * @return the quest object
+     */
+    public Quest getQuest(String questID, Boolean searchFS) {
         Quest result = this.getAllQuests().get(questID);
 
         // search in filesystem
-        if (result == null) {
+        if (result == null && searchFS) {
             System.err.println("Quest registry could not find quest: " + questID + ". It'll now search for it in the resources quest template files.");
 
             // attempt finding it in the files and uploading to database

--- a/src/main/resources/quest/templates/beans-tester-bonus.json
+++ b/src/main/resources/quest/templates/beans-tester-bonus.json
@@ -43,7 +43,7 @@
           "npc" : "npc_0",
           "dialogue" : [ "I'm Beans the Acacia Log (^^)" ],
           "connections" : {
-            "next" : "action_1",
+            "next" : "stage_0.action_1",
             "curr" : null,
             "prev" : null
           },
@@ -55,17 +55,17 @@
           "npc" : "npc_1",
           "dialogue" : [ "No! I'm the real Beans!!" ],
           "connections" : {
-            "next" : "action_0",
+            "next" : "stage_0.action_0",
             "curr" : null,
             "prev" : null
           },
           "id" : "action_1"
         }
       },
-      "entry" : "action_0",
+      "entry" : "stage_0.action_0",
       "connections" : {
         "next" : null,
-        "curr" : "action_0",
+        "curr" : "stage_0.action_0",
         "prev" : null
       }
     }


### PR DESCRIPTION
# Goals/Changes
- fix quest viewer thread blocking and/or communicate searching the filesystem for the quest
- add background quest loading with FS watcher
- fix when a quest is already toggled on reload, on remove, it doesn't remove from the diary
- fix when deleting a quest FX isn't updated
- fix quest diary entries duplicate when a quest is untoggled and retoggled
- fix listening for all player messages in ChatPrompt
- fix listening for all player block placing in SelectLocation
- fix cancelling chat when chat is a denied select method in SelectBlock
- remove redundant closes when using try-with-resources
  - aka improve database performance
- fix concurrency issues with database
  - enables durable quest progress and data. Quest progress persists despite reloads and restarts
- remove quest progress tracking debug console logs
- fixe un-started quests never added to new player quest diaries (regression)
- fix GUI clicks running for other players
- add closing GUI on server reload
- fix stage adding increment
  - after stage_1 is stage_11 instead of stage_2
- add StagePath for quest pointers ✨ 
  - instead of an action being referred to in the template as action_1 it's more precise, like stage_0.action_1.
- add latest release alert
- add quest resources refunding
- cap quest actions to 12
- cap quest stages to 42
- fix order of stage list in quest stages menu