### PR TITLE
Use quest caching instead of real-time database (and other QOL fixes)…

### DIFF
--- a/branding/docs/developers/README.md
+++ b/branding/docs/developers/README.md
@@ -28,11 +28,11 @@ TODO: Each <ins>quest</ins> is a <ins>container of stages</ins>. Each <ins>stage
 
 # How To Get Functionality: 'Templates'
 ###### We have Meta and Quest Actions, but how do we actually use them?
-TODO: Usually you would never need this, but this is what makes it all tick. When you create a Quest: stages, npcs, actions and all; this is the format and layout it is constructing:
+Usually you would never need this, but this is what makes it all tick. When you create a Quest: stages, npcs, actions and all; this is the format and layout it is constructing:
 ```json
 {
     "title": String, // label of the entire quest
-    "entry": String, // (as in 'entry point') where the quest starts
+    "entry": String, // Path: (as in 'entry point') where the quest starts
     "creator": UUID, // the player who created this quest
     "id": String, // the id, composed of: [Quest Title]_[Creator UUID]
     "npcs": { // directory of all the quest npcs
@@ -55,7 +55,7 @@ TODO: Usually you would never need this, but this is what makes it all tick. Whe
         "stage_0": { // Stage ID (automatically generated)
             "notable": Boolean, // if it would show up as a chapter in a book; a notable stage
             "label": String, // the label for just this stage, as if it were a chapter
-            "entry": String, // where the stage starts
+            "entry": String, // Path: where the stage starts
             "actions": { // directory of all this stage's actions
                 "action_0": {  // Action ID (automatically generated)
                     "type": String, // Quest Action type
@@ -70,15 +70,16 @@ TODO: Usually you would never need this, but this is what makes it all tick. Whe
                 }
             },
             "connections": { // defining where the stage is in the quest
-                "next": @Nullable String, // where to go if the stage succeeds
-                "curr": @Nullable String, // where to return to if the stage is exited
-                "prev": @Nullable String // where to go if the stage fails
+                "next": @Nullable String, // Path: where to go if the stage succeeds
+                "curr": @Nullable String, // Path: where to return to if the stage is exited
+                "prev": @Nullable String // Path: where to go if the stage fails
             }
         },
     }
 }
 ```
-*It's worth noting that just because the IDs are incremental, all starting from zero, doesn't mean they are expected to be kept/used in order or in sequence.*
+- *It's worth noting that just because the IDs are incremental, all starting from zero, doesn't mean they are expected to be kept/used in order or in sequence.*
+- *'Path:' means the string is represented something like: "stage_0.action_0", it can also be just like: "stage_0"*
 
 # How It All Works: 'Specification'
 ###### the way to visualise/think about, and implement the program.

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>moe.sammypanda</groupId>
   <artifactId>playerquests</artifactId>
-  <version>0.5</version>
+  <version>0.5.1</version>
 
   <packaging>jar</packaging>
 

--- a/src/main/java/playerquests/Core.java
+++ b/src/main/java/playerquests/Core.java
@@ -39,6 +39,7 @@ public class Core extends JavaPlugin {
     /**
      * Core class, to be instantiated by server.
      */
+    // TODO: always talk to database through a class (for caching and real-time data). Never talk directly! (It can't handle it).
     public Core() {}
 
     @Override
@@ -53,6 +54,11 @@ public class Core extends JavaPlugin {
 
         // mount bStats for some minimal usage info
         new Metrics(this, 22692);
+    }
+
+    @Override
+    public void onDisable() {
+        PlayerQuests.getServerListener().onDisable();
     }
 
     /**

--- a/src/main/java/playerquests/builder/gui/dynamic/Dynamicactioneditor.java
+++ b/src/main/java/playerquests/builder/gui/dynamic/Dynamicactioneditor.java
@@ -13,6 +13,7 @@ import playerquests.builder.gui.function.ChatPrompt; // prompts the user for inp
 import playerquests.builder.gui.function.UpdateScreen; // going to previous screen
 import playerquests.builder.quest.action.QuestAction; // describes a quest action
 import playerquests.builder.quest.data.ActionOption; // a setting that can be set for an action
+import playerquests.builder.quest.data.StagePath;
 import playerquests.builder.quest.npc.QuestNPC; // describes a quest NPC
 import playerquests.builder.quest.stage.QuestStage; // describes a quest stage
 import playerquests.client.ClientDirector; // controlling the plugin
@@ -58,7 +59,7 @@ public class Dynamicactioneditor extends GUIDynamic {
         this.putOptionSlots(Arrays.asList(1,2,3,10,11,12));
 
         // set label
-        if (this.stage.getEntryPoint().getID() == this.action.getID()) { // if this action is the entry point
+        if (this.stage.getEntryPoint().getAction() == this.action.getID()) { // if this action is the entry point
             this.gui.getFrame().setTitle(this.action + " Editor (Entry Point)");
         } else {
             this.gui.getFrame().setTitle(this.action + " Editor");
@@ -108,7 +109,7 @@ public class Dynamicactioneditor extends GUIDynamic {
             .setLabel("Delete Action")
             .setItem("RED_DYE")
             .onClick(() -> {
-                if (stage.getEntryPoint().equals(action)) {
+                if (stage.getEntryPoint().getAction(stage.getQuest()).equals(action)) {
                     ChatUtils.message("Cannot remove the stage starting point action.")
                         .player(this.director.getPlayer())
                         .type(MessageType.WARN)
@@ -140,7 +141,7 @@ public class Dynamicactioneditor extends GUIDynamic {
         entrypointButton.setItem("ENDER_EYE");
         entrypointButton.setLabel("Set Action As Entry Point");
         entrypointButton.onClick(() -> {
-            this.stage.setEntryPoint(this.action.getID()); // set this action as the stage entry point
+            this.stage.setEntryPoint(new StagePath(this.stage, this.action)); // set this action as the stage entry point
             this.execute(); // re-run to see changes
         });
 

--- a/src/main/java/playerquests/builder/gui/dynamic/Dynamicconnectioneditor.java
+++ b/src/main/java/playerquests/builder/gui/dynamic/Dynamicconnectioneditor.java
@@ -6,6 +6,7 @@ import java.util.Arrays;
 import playerquests.builder.gui.component.GUISlot;
 import playerquests.builder.gui.function.UpdateScreen;
 import playerquests.builder.quest.data.ConnectionsData;
+import playerquests.builder.quest.data.StagePath;
 import playerquests.client.ClientDirector;
 
 public class Dynamicconnectioneditor extends GUIDynamic {
@@ -26,9 +27,9 @@ public class Dynamicconnectioneditor extends GUIDynamic {
 
     @Override
     protected void execute_custom() {
-        String prev = this.connections.getPrev();
-        String curr = this.connections.getCurr();
-        String next = this.connections.getNext();
+        StagePath prev = this.connections.getPrev();
+        StagePath curr = this.connections.getCurr();
+        StagePath next = this.connections.getNext();
 
         this.gui.getFrame().setTitle("Sequence Editor");
 
@@ -88,7 +89,7 @@ public class Dynamicconnectioneditor extends GUIDynamic {
             Dynamicselectconnection connectionSelector = (Dynamicselectconnection) functionUpdateScreen.getDynamicGUI();
 
             connectionSelector.onSelect((selectionObject) -> {
-                String selection = selectionObject.toString();
+                StagePath selection = (StagePath) selectionObject;
 
                 switch (connection) {
                     case "prev":

--- a/src/main/java/playerquests/builder/gui/dynamic/Dynamicquesteditor.java
+++ b/src/main/java/playerquests/builder/gui/dynamic/Dynamicquesteditor.java
@@ -6,9 +6,10 @@ import java.util.Arrays; // generic array handling
 import playerquests.builder.gui.component.GUIFrame; // describes the outer GUI frame/window
 import playerquests.builder.gui.component.GUISlot; // describes a GUI button
 import playerquests.builder.gui.function.ChatPrompt; // GUI taking input from chat box
-import playerquests.builder.gui.function.Save; // saves data via GUI button
+import playerquests.builder.gui.function.Save;
 import playerquests.builder.gui.function.UpdateScreen; // changing the GUI screen to another
 import playerquests.builder.quest.QuestBuilder; // controlling a quest
+import playerquests.builder.quest.data.StagePath;
 import playerquests.client.ClientDirector; // accessing the client state
 
 /**
@@ -104,11 +105,9 @@ public class Dynamicquesteditor extends GUIDynamic {
                     Dynamicselectconnection selector = (Dynamicselectconnection) function.getDynamicGUI();
 
                     selector.onSelect((selected) -> {
-                        questBuilder.setEntryPoint(selector.selectedStage);
-
-                        if (selector.selectedAction != null) {
-                            selector.selectedStage.setEntryPoint(selector.selectedAction.getID());
-                        }
+                        // get the chosen entry point (as a stage path 'stage_[num].action_[num]' for precision)
+                        StagePath path = (StagePath) selected;
+                        questBuilder.setEntryPoint(new StagePath(path.getStage(), path.getAction()));
                     });
                 }).execute();
             });

--- a/src/main/java/playerquests/builder/gui/dynamic/Dynamicquestnpcs.java
+++ b/src/main/java/playerquests/builder/gui/dynamic/Dynamicquestnpcs.java
@@ -99,6 +99,7 @@ public class Dynamicquestnpcs extends GUIDynamic {
         addButton.setLabel("Add NPC");
         addButton.onClick(() -> {
             QuestNPC npc = new QuestNPC(); // create new empty npc
+            npc.setQuest(questBuilder.build());
             this.director.setCurrentInstance(npc);
 
             new UpdateScreen(

--- a/src/main/java/playerquests/builder/gui/dynamic/Dynamicqueststage.java
+++ b/src/main/java/playerquests/builder/gui/dynamic/Dynamicqueststage.java
@@ -107,7 +107,7 @@ public class Dynamicqueststage extends GUIDynamic {
                 GUISlot actionSlot = new GUISlot(this.gui, nextEmptySlot);
 
                 // identify which action is the stage entry point
-                if (this.questStage.getEntryPoint().getID().equals(action)) { // if this action is the entry point
+                if (this.questStage.getEntryPoint().getAction().equals(action)) { // if this action is the entry point
                     actionSlot.setLabel(action.toString() + " (Entry Point)");
                     actionSlot.setItem("POWERED_RAIL");
                 } else { // if it's not the entry point
@@ -170,14 +170,20 @@ public class Dynamicqueststage extends GUIDynamic {
 
         // add 'new action' button
         GUISlot newActionButton = new GUISlot(this.gui, this.gui.getFrame().getSize());
-        newActionButton.setLabel("Add Action");
-        newActionButton.setItem("LIME_DYE");
-        newActionButton.onClick(() -> {
-            new None(this.questStage).submit(); // create the new action
-            this.confirm_actionKeys = false; // set actionKeys to be looped through again
-            this.gui.clearSlots();
-            this.execute(); // re-run to see new action in list
-        });
+        
+        if (this.questStage.getActions().size() < 12) {
+            newActionButton.setLabel("Add Action");
+            newActionButton.setItem("LIME_DYE");
+            newActionButton.onClick(() -> {
+                new None(this.questStage).submit(); // create the new action
+                this.confirm_actionKeys = false; // set actionKeys to be looped through again
+                this.gui.clearSlots();
+                this.execute(); // re-run to see new action in list
+            });
+        } else {
+            newActionButton.setLabel("No More Action Slots");
+            newActionButton.setItem("BARRIER");
+        }
     }
     
 }

--- a/src/main/java/playerquests/builder/gui/dynamic/Dynamicqueststages.java
+++ b/src/main/java/playerquests/builder/gui/dynamic/Dynamicqueststages.java
@@ -59,10 +59,14 @@ public class Dynamicqueststages extends GUIDynamic {
         this.gui.getFrame().setTitle(this.guiTitle); // set the GUI title
         this.gui.getFrame().setSize( // set number of slots in the GUI
             Math.min( // get up to 54 (maximum slots)
-                (this.questBuilder.getStages().size() + 9) / 9 * 9, // only multiples of 9
+                (this.questBuilder.getStages().size() + 20) / 9 * 9, // only multiples of 9
                 54 // 54 maximum slots
             )
         );
+
+        // restart inv in-case GUI size is changed
+        this.gui.getResult().minimise();
+        this.gui.getResult().open();
 
         // dividers (first two rows)
         IntStream.iterate(1, n -> n + 9).limit(54/9).forEach((divSlot) -> {
@@ -83,21 +87,22 @@ public class Dynamicqueststages extends GUIDynamic {
         ));
 
         // add new stage button
-        new GUISlot(this.gui, this.gui.getFrame().getSize())
-            .setLabel("Add Stage")
-            .setItem("LIME_DYE")
-            .onClick(() -> {
-                questBuilder.addStage(
-                    new QuestStage(
-                        this.questBuilder.build(), 
-                        this.questBuilder.getStages().isEmpty() ? 0 : Integer.parseInt(this.questBuilder.getStages().getLast().substring(6) + 1)
-                    )
-                );
+        if (this.questBuilder.getStages().size() < 42) {
+            new GUISlot(this.gui, this.gui.getFrame().getSize())
+                .setLabel("Add Stage")
+                .setItem("LIME_DYE")
+                .onClick(() -> {
+                    questBuilder.addStage(
+                        new QuestStage(
+                            this.questBuilder.build(), 
+                            this.questBuilder.getStages().isEmpty() ? 0 : Integer.parseInt(this.questBuilder.getStages().getLast().substring(6)) + 1
+                        )
+                    );
 
-                this.gui.clearSlots();
-
-                this.execute(); // rebuild GUI
-            });
+                    this.gui.clearSlots();
+                    this.execute(); // rebuild GUI
+                });
+        }
 
         IntStream.range(0, this.questBuilder.getStages().size()).anyMatch(index -> {
 

--- a/src/main/java/playerquests/builder/gui/dynamic/Dynamicselectconnection.java
+++ b/src/main/java/playerquests/builder/gui/dynamic/Dynamicselectconnection.java
@@ -11,6 +11,7 @@ import playerquests.builder.gui.component.GUISlot;
 import playerquests.builder.gui.function.UpdateScreen;
 import playerquests.builder.quest.QuestBuilder;
 import playerquests.builder.quest.action.QuestAction;
+import playerquests.builder.quest.data.StagePath;
 import playerquests.builder.quest.stage.QuestStage;
 import playerquests.client.ClientDirector;
 
@@ -19,17 +20,17 @@ public class Dynamicselectconnection extends GUIDynamic {
     /**
      * The quest we are editing.
      */
-    QuestBuilder questBuilder;
+    private QuestBuilder questBuilder;
     
     /**
      * The stage that has been selected.
      */
-    QuestStage selectedStage = null;
+    private QuestStage selectedStage = null;
 
     /**
      * The action that has been selected.
      */
-    QuestAction selectedAction = null;
+    private QuestAction selectedAction = null;
 
     /**
      * The code to run on connection select.
@@ -59,7 +60,7 @@ public class Dynamicselectconnection extends GUIDynamic {
                 .setLabel("Just Select This Stage")
                 .setItem("YELLOW_DYE")
                 .onClick(() -> {
-                    this.select(this.selectedStage);
+                    this.select(new StagePath(selectedStage, null)); // just select a stage
                 });
 
             int rangeOffset = 2; // the amount to subtract from the slot number, to get an index from 0
@@ -78,7 +79,7 @@ public class Dynamicselectconnection extends GUIDynamic {
                     .setItem("DETECTOR_RAIL")
                     .onClick(() -> {
                         this.selectedAction = action;
-                        this.select(action);
+                        this.select(new StagePath(selectedStage, action));
                     });
             });
 
@@ -132,9 +133,11 @@ public class Dynamicselectconnection extends GUIDynamic {
      * Called when a connection is selected.
      * @param object the selected stage/action
      */
-    private void select(Object connection) {
+    private void select(StagePath path) {
         if (this.onSelect != null) {
-            onSelect.accept(connection);
+            onSelect.accept(
+                new StagePath(selectedStage, selectedAction)
+            );
         }
 
         new UpdateScreen(
@@ -151,7 +154,7 @@ public class Dynamicselectconnection extends GUIDynamic {
      */
     public Object onSelect(Consumer<Object> onSelect) {
         this.onSelect = onSelect;
-        return this.selectedAction;
+        return onSelect;
     }
     
 }

--- a/src/main/java/playerquests/builder/gui/function/ChatPrompt.java
+++ b/src/main/java/playerquests/builder/gui/function/ChatPrompt.java
@@ -8,7 +8,8 @@ import org.bukkit.event.HandlerList; // to unregister event listener (ChatPrompt
 import org.bukkit.event.Listener; // to register event listener (ChatPromptListener)
 import org.bukkit.event.player.AsyncPlayerChatEvent;
 import org.bukkit.ChatColor; // used to format the chat messages to guide user input/UX
-import org.bukkit.entity.HumanEntity; // refers to the player
+import org.bukkit.entity.HumanEntity; // usually the player
+import org.bukkit.entity.Player; // refers to the player
 
 import playerquests.Core; // used to access the Plugin and KeyHandler instances
 import playerquests.client.ClientDirector; // powers functionality for functions
@@ -31,11 +32,17 @@ public class ChatPrompt extends GUIFunction {
         private ChatPrompt parentClass;
 
         /**
+         * The player this listener is for.
+         */
+        private Player player;
+
+        /**
          * Creates a new listener for chat prompt inputs.
          * @param parent the origin ChatPrompt GUI function
          */
-        public ChatPromptListener(ChatPrompt parent) {
+        public ChatPromptListener(ChatPrompt parent, Player player) {
             this.parentClass = parent;
+            this.player = player;
         }
 
         /**
@@ -44,6 +51,10 @@ public class ChatPrompt extends GUIFunction {
          */
         @EventHandler
         private void onChat(AsyncPlayerChatEvent event) {
+            if (this.player != event.getPlayer()) {
+                return; // do not capture other players events
+            }
+
             event.setCancelled(true); // cancel the chat message from sending to others
             this.parentClass.setResponse(event.getMessage()); // set the user response
             this.parentClass.execute(); // loop back to the function
@@ -110,8 +121,8 @@ public class ChatPrompt extends GUIFunction {
         // set initial values
         this.prompt = (String) params.get(0);
         this.key = (String) params.get(1);
-        this.chatListener = new ChatPromptListener(this);
         this.player = this.director.getPlayer();
+        this.chatListener = new ChatPromptListener(this, Bukkit.getPlayer(this.player.getUniqueId()));
 
         try {
             PluginUtils.validateParams(this.params, String.class, String.class);

--- a/src/main/java/playerquests/builder/gui/function/SelectBlock.java
+++ b/src/main/java/playerquests/builder/gui/function/SelectBlock.java
@@ -9,6 +9,7 @@ import org.bukkit.ChatColor;
 import org.bukkit.Material; // the resulting material (block)
 import org.bukkit.block.Block; // spigot block type
 import org.bukkit.entity.HumanEntity;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler; // registering methods as event handlers
 import org.bukkit.event.HandlerList; // unregistering event handlers
 import org.bukkit.event.Listener; // listening to in-game events
@@ -35,6 +36,11 @@ public class SelectBlock extends GUIFunction {
         private SelectBlock parentClass;
 
         /**
+         * The player this listener is for.
+         */
+        private Player player;
+
+        /**
          * Select methods to not allow.
          */
         private List<SelectMethod> deniedMethods;
@@ -43,13 +49,18 @@ public class SelectBlock extends GUIFunction {
          * Creates a new listener for chat prompt inputs.
          * @param parent the origin ChatPrompt GUI function
          */
-        public SelectBlockListener(SelectBlock parent) {
+        public SelectBlockListener(SelectBlock parent, Player player) {
             this.parentClass = parent;
+            this.player = player;
             this.deniedMethods = parent.getDeniedMethods();
         }
-
+        
         @EventHandler
         private void onHit(PlayerInteractEvent event) {
+            if (this.player != event.getPlayer()) {
+                return; // do not capture other players events
+            }
+            
             if (deniedMethods.contains(SelectMethod.HIT)) {
                 return; // do not continue
             }
@@ -65,6 +76,10 @@ public class SelectBlock extends GUIFunction {
 
         @EventHandler
         private void onSelect(InventoryClickEvent event) {
+            if (this.player != event.getWhoClicked()) {
+                return; // do not capture other players events
+            }
+
             if (deniedMethods.contains(SelectMethod.SELECT)) {
                 return; // do not continue
             }
@@ -83,6 +98,14 @@ public class SelectBlock extends GUIFunction {
 
         @EventHandler
         private void onChat(AsyncPlayerChatEvent event) {
+            if (this.player != event.getPlayer()) {
+                return; // do not capture other players events
+            }
+
+            if (deniedMethods.contains(SelectMethod.CHAT)) {
+                return; // do not continue
+            }
+
             event.setCancelled(true);
 
             Bukkit.getScheduler().runTask(Core.getPlugin(), () -> { // run on next tick
@@ -95,7 +118,6 @@ public class SelectBlock extends GUIFunction {
                     }
                 }
             });
-            
         }
     }
 
@@ -189,7 +211,7 @@ public class SelectBlock extends GUIFunction {
         this.director.getGUI().getResult().minimise();
 
         // register events and listener
-        this.blockListener = new SelectBlockListener(this);
+        this.blockListener = new SelectBlockListener(this, Bukkit.getPlayer(this.player.getUniqueId()));
         Bukkit.getPluginManager().registerEvents(this.blockListener, Core.getPlugin());
 
         // mark this function class as setup

--- a/src/main/java/playerquests/builder/gui/function/SelectLocation.java
+++ b/src/main/java/playerquests/builder/gui/function/SelectLocation.java
@@ -8,6 +8,7 @@ import org.bukkit.Material; // used to create fallback BlockData
 import org.bukkit.block.Block; // data object representing a placed block
 import org.bukkit.block.data.BlockData; // data object representing the metadata of a block
 import org.bukkit.entity.HumanEntity; // usually the player
+import org.bukkit.entity.Player; // refers to the player
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
@@ -32,15 +33,25 @@ public class SelectLocation extends GUIFunction {
         private SelectLocation parentClass;
 
         /**
+         * The player this listener is for.
+         */
+        private Player player;
+
+        /**
          * Creates a new listener for chat prompt inputs.
          * @param parent the origin ChatPrompt GUI function
          */
-        public SelectLocationListener(SelectLocation parent) {
+        public SelectLocationListener(SelectLocation parent, Player player) {
             this.parentClass = parent;
+            this.player = player;
         }
 
         @EventHandler
         private void onBlockPlace(BlockPlaceEvent event) {
+            if (this.player != event.getPlayer()) {
+                return; // do not capture other players events
+            }
+
             event.setCancelled(true);
 
             Block blockPlaced = event.getBlockPlaced();
@@ -115,7 +126,7 @@ public class SelectLocation extends GUIFunction {
         this.director.getGUI().getResult().minimise();
 
         // register events and listener
-        this.locationListener = new SelectLocationListener(this);
+        this.locationListener = new SelectLocationListener(this, Bukkit.getPlayer(this.player.getUniqueId()));
         Bukkit.getPluginManager().registerEvents(this.locationListener, Core.getPlugin());
 
         // mark this function class as setup

--- a/src/main/java/playerquests/builder/quest/QuestBuilder.java
+++ b/src/main/java/playerquests/builder/quest/QuestBuilder.java
@@ -1,5 +1,6 @@
 package playerquests.builder.quest;
 
+import java.util.Comparator;
 import java.util.HashMap; // hash table map type
 import java.util.LinkedList;
 import java.util.Map; // generic map type
@@ -7,10 +8,13 @@ import java.util.UUID;
 import java.util.stream.Collectors; // accumulating elements from a stream into a type
 import java.util.stream.IntStream; // used to iterate over a range
 
+import org.bukkit.Bukkit;
+
 import com.fasterxml.jackson.annotation.JsonIgnore; // remove fields from serialising to json
 import com.fasterxml.jackson.annotation.JsonProperty; // for declaring a field as a json property
 
 import playerquests.Core; // gets the KeyHandler singleton
+import playerquests.builder.quest.data.StagePath;
 import playerquests.builder.quest.npc.QuestNPC; // quest npc builder
 import playerquests.builder.quest.stage.QuestStage; // quest stage builder
 import playerquests.client.ClientDirector; // abstractions for plugin functionality
@@ -48,7 +52,7 @@ public class QuestBuilder {
     /**
      * Entry point for the quest.
      */
-    private QuestStage entryPoint;
+    private StagePath entryPoint;
 
     /**
      * Map of the NPC characters.
@@ -83,11 +87,17 @@ public class QuestBuilder {
         this.director = director;
 
         // default entry point as first stage (stage_0)
-        this.entryPoint = new QuestStage(this.build(), 0);
-        director.setCurrentInstance(this.entryPoint); // make it modifiable
+        QuestStage stage = new QuestStage(this.build(), 0);
+        this.entryPoint = new StagePath(
+            stage,
+            null
+        );
+        
+        // make it modifiable
+        director.setCurrentInstance(stage);
 
         // add default entry point stage to questPlan map
-        this.questPlan.put(this.entryPoint.getID(), this.entryPoint);
+        this.questPlan.put(stage.getID(), stage);
 
         // set as the current quest in the director
         director.setCurrentInstance(this);
@@ -108,8 +118,9 @@ public class QuestBuilder {
             this.title = product.getTitle();
 
             // add the entry point stage from the product
-            this.entryPoint = product.getStages().get(product.getEntry());
-            director.setCurrentInstance(this.entryPoint); // make it modifiable
+            QuestStage entryStage = product.getStages().get(product.getEntry().getStage());
+            this.entryPoint = new StagePath(entryStage, null);
+            director.setCurrentInstance(entryStage); // make it modifiable
 
             // add the stages from the product
             this.questPlan = product.getStages();
@@ -208,7 +219,7 @@ public class QuestBuilder {
      */
     @JsonProperty("entry")
     public String getEntryPointString() {
-        return this.entryPoint.getID();
+        return this.entryPoint.toString();
     }
 
     /**
@@ -217,8 +228,8 @@ public class QuestBuilder {
      * Should be a stage.
      * @param stage what the entry point stage is
      */
-    public void setEntryPoint(QuestStage stage) {
-        this.entryPoint = stage;
+    public void setEntryPoint(StagePath path) {
+        this.entryPoint = path;
     }
 
     /**
@@ -227,7 +238,14 @@ public class QuestBuilder {
      */
     @JsonIgnore
     public LinkedList<String> getStages() {
-        return new LinkedList<String>(this.questPlan.keySet());
+        // create an ordered list of stages, ordered by stage_[this number]
+        LinkedList<String> orderedList = this.questPlan.keySet().stream()
+            .map(stage -> stage.split("_"))
+            .sorted(Comparator.comparingInt(parts -> Integer.parseInt(parts[1])))
+            .map(parts -> String.join("_", parts))
+            .collect(Collectors.toCollection(LinkedList::new));
+
+        return orderedList;
     }
 
     /**
@@ -301,6 +319,8 @@ public class QuestBuilder {
      */
     public void removeNPC(QuestNPC npc) {
         this.questNPCs.remove(npc.getID());
+
+        npc.refund(Bukkit.getPlayer(this.getDirector().getPlayer().getUniqueId()));
     }
 
     /**
@@ -338,7 +358,8 @@ public class QuestBuilder {
             this.entryPoint,
             this.questNPCs,
             this.questPlan,
-            this.universal ? null : this.director.getPlayer().getUniqueId()
+            this.universal ? null : this.director.getPlayer().getUniqueId(),
+            true // always toggle cloned quests on when freshly cloned
         );
 
         // set this quest as in-focus to the creator

--- a/src/main/java/playerquests/builder/quest/action/Speak.java
+++ b/src/main/java/playerquests/builder/quest/action/Speak.java
@@ -5,7 +5,6 @@ import java.util.Arrays; // generic array type
 import java.util.List; // generic list type
 import java.util.Optional;
 
-import org.bukkit.Bukkit; // bukkit API
 import org.bukkit.entity.Player; // represents a bukkit player
 
 import playerquests.builder.quest.data.ActionOption; // enums for possible options to add to an action
@@ -42,7 +41,7 @@ public class Speak extends QuestAction {
 
     @Override
     public void Run(QuestClient quester) {
-        Player player = Bukkit.getPlayer(quester.getPlayer().getUniqueId());
+        Player player = quester.getPlayer();
 
         // insert empty dialogue if none set
         if (this.dialogue == null) {

--- a/src/main/java/playerquests/builder/quest/data/ConnectionsData.java
+++ b/src/main/java/playerquests/builder/quest/data/ConnectionsData.java
@@ -7,9 +7,9 @@ import com.fasterxml.jackson.annotation.JsonIgnore; // used to ignore fields in 
  * to form a network/quest plan.
  */
 public class ConnectionsData {
-    private String next;
-    private String curr;
-    private String prev;
+    private StagePath next;
+    private StagePath curr;
+    private StagePath prev;
 
     /**
      * Defaut constructor (for Jackson)
@@ -23,7 +23,7 @@ public class ConnectionsData {
      * @param curr where to return to if the stage is exited
      * @param prev where to go if the stage fails
      */
-    public ConnectionsData(String next, String curr, String prev) {
+    public ConnectionsData(StagePath next, StagePath curr, StagePath prev) {
         this.next = next;
         this.curr = curr;
         this.prev = prev;
@@ -33,7 +33,7 @@ public class ConnectionsData {
      * Gets the next quest stage or action.
      * @return next stage or action.
      */
-    public String getNext() {
+    public StagePath getNext() {
         return this.next;
     }
 
@@ -41,7 +41,7 @@ public class ConnectionsData {
      * Sets the next quest stage or action.
      * @param next a quest stage or action.
      */
-    public void setNext(String next) {
+    public void setNext(StagePath next) {
         this.next = next;
     }
 
@@ -49,7 +49,7 @@ public class ConnectionsData {
      * Gets the on-exit quest stage or action.
      * @return on-exit stage or action.
      */
-    public String getCurr() {
+    public StagePath getCurr() {
         return this.curr;
     }
 
@@ -57,7 +57,7 @@ public class ConnectionsData {
      * Sets the on-exit quest stage or action.
      * @param next a quest stage or action.
      */
-    public void setCurr(String curr) {
+    public void setCurr(StagePath curr) {
         this.curr = curr;
     }
 
@@ -65,7 +65,7 @@ public class ConnectionsData {
      * Gets the prior quest stage or action.
      * @return prior stage or action.
      */
-    public String getPrev() {
+    public StagePath getPrev() {
         return this.prev;
     }
 
@@ -73,7 +73,7 @@ public class ConnectionsData {
      * Sets the prior quest stage or action.
      * @param next a quest stage or action.
      */
-    public void setPrev(String prev) {
+    public void setPrev(StagePath prev) {
         this.prev = prev;
     }
 

--- a/src/main/java/playerquests/builder/quest/data/StagePath.java
+++ b/src/main/java/playerquests/builder/quest/data/StagePath.java
@@ -1,0 +1,146 @@
+package playerquests.builder.quest.data;
+
+import javax.annotation.Nullable;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import playerquests.builder.quest.action.QuestAction;
+import playerquests.builder.quest.stage.QuestStage;
+import playerquests.product.Quest;
+
+/**
+ * Represents a path within a quest, consisting of a stage and optionally an action.
+ * 
+ * This class provides various constructors for creating a {@code StagePath} from different types of input
+ * and methods for retrieving the stage and action details.
+ * 
+ * The {@code StagePath} can be initialized using:
+ * <ul>
+ *   <li>A single string path (suitable for Jackson deserialization), where the string is split by a period (".") to determine the stage and action.</li>
+ *   <li>Objects of type {@code QuestStage} and {@code QuestAction}, where the IDs of these objects are used to set the stage and action.</li>
+ *   <li>Two separate strings for stage and action.</li>
+ * </ul>
+ * 
+ * This class also includes methods to retrieve the corresponding {@code QuestStage} and {@code QuestAction}
+ * objects from a {@code Quest} based on the stored IDs.
+ */
+public class StagePath {
+    private String stage;
+    private String action;
+
+    /**
+     * Constructs a new {@code StagePath} from string values. 
+     * (good for Jackson deserialisation).
+     * 
+     * @param path the StagePath as a string
+     * @param id the Quest ID as a string
+     */
+    public StagePath(String path) {
+        // segment[0] = stage_?
+        // segment[1] (if exists) = action_?
+        String[] segments = path.split("\\.");
+
+        // for backwards compatibility and dummies; segment[0] = action_?
+        if (segments[0].contains("action")) {
+            this.action = segments[0];
+            return;
+        }
+
+        // for correct string representation/template behaviour
+        this.stage = segments[0];
+        this.action = null;
+
+        if (segments.length > 1) {
+            this.action = segments[1]; 
+        }
+    }
+
+    /**
+     * Constructs a new {@code StagePath} from actual objects.
+     * 
+     * @param path the StagePath as a string
+     * @param id the Quest ID as a string
+     */
+    public StagePath(QuestStage stage, @Nullable QuestAction action) {
+        this.stage = stage.getID();
+        this.action = null;
+
+        if (action != null) {
+            this.action = action.getID();
+        }
+    }
+
+    /**
+     * Constructs a new {@code StagePath} from disjoined strings.
+     * 
+     * @param path the StagePath as a string
+     * @param id the Quest ID as a string
+     */
+    public StagePath(String stage, @Nullable String action) {
+        this.stage = stage;
+        this.action = action;
+    }
+
+    /**
+     * Returns the quest stage ID.
+     *
+     * @return the quest stage ID
+     */
+    public String getStage() {
+        return stage != null ? stage : "stage_0";
+    }
+
+    /**
+     * Returns the quest stage object.
+     *
+     * @return the quest stage
+     */
+    public QuestStage getStage(Quest quest) {
+        // if somehow the stage is null
+        if (stage == null) {
+            return quest.getStages().values().iterator().next();
+        }
+
+        return quest.getStages().get(stage);
+    }
+
+    /**
+     * Returns the quest action ID.
+     *
+     * @return the quest action ID
+     */
+    public String getAction() {
+        return action != null ? action : null;
+    }
+
+    /**
+     * Returns the quest action object.
+     *
+     * @return the quest action
+     */
+    public QuestAction getAction(Quest quest) {
+        QuestStage stage = this.getStage(quest);
+
+        if (this.action == null) {
+            return stage.getEntryPoint().getAction(quest); // try next entry point
+        }
+
+        return stage.getActions().get(action);
+    }
+
+    /**
+     * Returns a string representation of this {@code StagePath}, in the format
+     * "[stage ID].[action ID]" or "[stage ID]".
+     *
+     * @return a string representation of this stage and action reference
+     */
+    @JsonValue
+    public String toString() {
+        String action = this.getAction(); // will be action if it exists, otherwise null
+
+        return String.format("%s%s",
+            this.getStage(),
+            action != null ? "."+action : ""
+        );
+    }
+}

--- a/src/main/java/playerquests/builder/quest/npc/BlockNPC.java
+++ b/src/main/java/playerquests/builder/quest/npc/BlockNPC.java
@@ -3,10 +3,13 @@ package playerquests.builder.quest.npc;
 import org.bukkit.Bukkit;
 import org.bukkit.Material; // deprecated: material representing the block, representing this NPC
 import org.bukkit.block.data.BlockData; // block representing this NPC
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
 
 import com.fasterxml.jackson.annotation.JsonIgnore; // to ignore serialising properties
 import com.fasterxml.jackson.annotation.JsonProperty; // to set how a property serialises
 
+import playerquests.Core;
 import playerquests.utility.singleton.PlayerQuests;
 
 public class BlockNPC extends NPCType {
@@ -73,7 +76,9 @@ public class BlockNPC extends NPCType {
     @Override
     @JsonIgnore
     public void place() {
-        PlayerQuests.getInstance().putBlockNPC(this);
+        Bukkit.getScheduler().runTask(Core.getPlugin(), () -> {
+            PlayerQuests.getInstance().putBlockNPC(this);
+        });   
     }
 
     /**
@@ -85,5 +90,14 @@ public class BlockNPC extends NPCType {
         this.npc.setLocation(null);
 
         PlayerQuests.getInstance().putBlockNPC(this);
+    }
+
+    @Override
+    @JsonIgnore
+    public void refund(Player player) {
+        // return the NPC block to the player
+        player.getInventory().addItem(
+            new ItemStack(this.getBlock().getMaterial())
+        );
     }
 }

--- a/src/main/java/playerquests/builder/quest/npc/NPCType.java
+++ b/src/main/java/playerquests/builder/quest/npc/NPCType.java
@@ -3,6 +3,8 @@ package playerquests.builder.quest.npc;
 import java.util.ArrayList; // array type of list
 import java.util.List; // generic list type
 
+import org.bukkit.entity.Player;
+
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
@@ -123,5 +125,12 @@ public class NPCType {
      */
     public void remove() {
         throw new IllegalStateException("Tried to remove an NPC that has not been given a type. (or the type has not correctly overriden the place method)");
+    }
+
+    /**
+     * Refund the resources used for the NPC.
+     */
+    public void refund(Player player) {
+        throw new IllegalStateException("Tried to refund an NPC that has not been given a type. (or the type has not correctly overriden the place method)");
     }
 }

--- a/src/main/java/playerquests/builder/quest/npc/QuestNPC.java
+++ b/src/main/java/playerquests/builder/quest/npc/QuestNPC.java
@@ -6,6 +6,7 @@ import org.bukkit.Bukkit; // bukkit singleton
 import org.bukkit.Material; // for if NPC is a block
 import org.bukkit.block.data.BlockData;
 import org.bukkit.entity.HumanEntity; // the player
+import org.bukkit.entity.Player;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonIgnore; // ignore a field when serialising to a JSON object
@@ -17,7 +18,9 @@ import playerquests.builder.quest.QuestBuilder;
 import playerquests.builder.quest.data.LocationData; // quest entity locations
 import playerquests.client.ClientDirector; // for controlling the plugin
 import playerquests.product.Quest;
-import playerquests.utility.ChatUtils; // sends error messages to player
+import playerquests.utility.ChatUtils.MessageBuilder;
+import playerquests.utility.ChatUtils.MessageStyle;
+import playerquests.utility.ChatUtils.MessageTarget;
 import playerquests.utility.ChatUtils.MessageType;
 import playerquests.utility.annotation.Key; // key-value pair annottation
 
@@ -162,42 +165,41 @@ public class QuestNPC {
     public boolean isValid() {
         UUID questCreator = quest.getCreator();
         HumanEntity player = null;
+        MessageBuilder response = new MessageBuilder("Something is wrong with a quest NPC") // default message; default sends to console
+            .type(MessageType.ERROR)
+            .target(MessageTarget.CONSOLE)
+            .style(MessageStyle.PLAIN);
+        Boolean isValid = true; // assume is valid
+
+        if (this.name == null) {
+            response.content("The NPC name must be set");
+            isValid = false;
+        }
+
+        if (this.assigned == null) {
+            response.content("The NPC must be assigned to a type");
+            isValid = false;
+        }
+
+        if (this.location == null) {
+            response.content("The NPC must be placed at a location");
+            isValid = false;
+        }
 
         // when there is a quest creator, try set player object from creator UUID
         if (questCreator != null) {
             player = Bukkit.getPlayer(quest.getCreator()); // the player to send invalid npc messages to
-        }
-
-        // when player not findable
-        if (player == null) {
-            return false;
-        }
-
-        if (this.name == null) {
-            ChatUtils.message("The NPC name must be set")
+            response // send a message to the player
                 .player(player)
-                .type(MessageType.WARN)
-                .send();
-            return false;
+                .style(MessageStyle.PRETTY);
         }
 
-        if (this.assigned == null) {
-            ChatUtils.message("The NPC must be assigned to a type")
-                .player(player)
-                .type(MessageType.WARN)
-                .send();
-            return false;
+        // send the response
+        if (!isValid) {
+            response.send(); // send our :( message
         }
 
-        if (this.location == null) {
-            ChatUtils.message("The NPC must be placed at a location")
-                .player(player)
-                .type(MessageType.WARN)
-                .send();
-            return false;
-        }
-
-        return true;
+        return isValid;
     }
     
     /**
@@ -205,6 +207,12 @@ public class QuestNPC {
      */
     @JsonIgnore
     public void assign(NPCType npcType) {
+        Player player = Bukkit.getPlayer(this.quest.getCreator());
+
+        if (this.assigned != null && player != null) { // if already assigned to something
+            this.refund(player);
+        }
+
         this.assigned = npcType;
     }
 
@@ -279,5 +287,10 @@ public class QuestNPC {
      */
     public void setQuest(Quest quest) {
         this.quest = quest;
+    }
+
+    @JsonIgnore
+    public void refund(Player player) {
+        this.getAssigned().refund(player);
     }
 }

--- a/src/main/java/playerquests/builder/quest/stage/QuestStage.java
+++ b/src/main/java/playerquests/builder/quest/stage/QuestStage.java
@@ -12,6 +12,7 @@ import playerquests.Core; // accessing plugin singeltons
 import playerquests.builder.quest.action.None; // default QuestAction type
 import playerquests.builder.quest.action.QuestAction; // abstract class for quest actions
 import playerquests.builder.quest.data.ConnectionsData;
+import playerquests.builder.quest.data.StagePath;
 import playerquests.product.Quest; // back reference to quest this stage belongs to
 import playerquests.utility.annotation.Key; // to associate a key name with a method
 
@@ -48,7 +49,7 @@ public class QuestStage {
      * Entry point action for the stage.
      */
     @JsonProperty("entry")
-    private String entryPoint;
+    private StagePath entryPoint;
 
     /**
      * The connections for the quest stage.
@@ -71,10 +72,10 @@ public class QuestStage {
         Core.getKeyHandler().registerInstance(this); // add the current quest stage to be accessed with key-pair syntax
 
         // create the default first action
-        String action = new None(this).submit().getID();
+        QuestAction action = new None(this).submit();
 
         // set the default first action as the default entry point
-        this.setEntryPoint(action);
+        this.setEntryPoint(new StagePath(this, action));
     }
 
     /**
@@ -92,10 +93,10 @@ public class QuestStage {
         Core.getKeyHandler().registerInstance(this); // add the current quest stage to be accessed with key-pair syntax
 
         // create the default first action
-        String action = new None(this).submit().getID();
+        QuestAction action = new None(this).submit();
 
         // set the default first action as the default entry point
-        this.setEntryPoint(action);
+        this.setEntryPoint(new StagePath(this, action));
     }
 
     /**
@@ -170,15 +171,14 @@ public class QuestStage {
      */
     public void removeAction(QuestAction action) {
         this.actions.remove(action.getID());
-        this.quest.save();
     }
 
     /**
      * Sets the first action executed when this stage is reached.
      * @param action a quest action id
      */
-    public void setEntryPoint(String action) {
-        this.entryPoint = action;
+    public void setEntryPoint(StagePath path) {
+        this.entryPoint = path;
     }
 
     /**
@@ -186,8 +186,8 @@ public class QuestStage {
      * @return a quest action id
      */
     @JsonIgnore
-    public QuestAction getEntryPoint() {
-        return this.actions.get(this.entryPoint);
+    public StagePath getEntryPoint() {
+        return this.entryPoint;
     }
 
     /**
@@ -211,8 +211,8 @@ public class QuestStage {
         newActionInstance.setID(currentAction); // update the ID in the action local
         this.actions.replace(currentAction, newActionInstance); // replace in main list
 
-        if (currentAction.equals(this.entryPoint)) {
-            this.entryPoint = newActionInstance.getID();
+        if (currentAction.equals(this.entryPoint.getAction())) {
+            this.entryPoint = new StagePath(this, newActionInstance);
         }
     }
 

--- a/src/main/java/playerquests/client/ClientDirector.java
+++ b/src/main/java/playerquests/client/ClientDirector.java
@@ -5,14 +5,14 @@ import java.util.HashMap; // holds the current instances
 import org.bukkit.entity.HumanEntity; // the player who controls the client
 
 import playerquests.builder.gui.GUIBuilder; // class to control and get GUI product
-import playerquests.builder.quest.QuestBuilder; // class to control and get Quest product
+import playerquests.utility.singleton.PlayerQuests; // the main plugin class
 
 /**
  * Class which provides simple abstractions for clients to use.
  * <p>
  * Used to control the plugin and keep reference of client state.
  */
-public class ClientDirector {
+public class ClientDirector extends Director {
     /**
      * One of every key-mutable instance
      */
@@ -33,6 +33,9 @@ public class ClientDirector {
 
         // validate the current instances map is correct/has everything
         this.validateCurrentInstances();
+
+        // store the director
+        PlayerQuests.getInstance().addDirector(this);
     }
 
     /**
@@ -44,7 +47,6 @@ public class ClientDirector {
     private void validateCurrentInstances() {
         // keep a default GUIBuilder available 
         currentInstances.putIfAbsent(GUIBuilder.class, new GUIBuilder(this));
-        currentInstances.putIfAbsent(QuestBuilder.class, new QuestBuilder(this));
     }
 
     /**
@@ -120,5 +122,10 @@ public class ClientDirector {
     public void clearCurrentInstances() {
         this.currentInstances.clear();
         this.validateCurrentInstances();
+    }
+
+    @Override
+    public void close() {
+        this.getGUI().getResult().close();
     }
 }

--- a/src/main/java/playerquests/client/Director.java
+++ b/src/main/java/playerquests/client/Director.java
@@ -1,0 +1,8 @@
+package playerquests.client;
+
+public abstract class Director {
+    /**
+     * Closes the director.
+     */
+    public abstract void close();
+}

--- a/src/main/java/playerquests/client/gui/listener/GUIListener.java
+++ b/src/main/java/playerquests/client/gui/listener/GUIListener.java
@@ -168,12 +168,13 @@ public class GUIListener implements Listener {
      */
     @EventHandler
     public void onClickItem(InventoryClickEvent event) {
-        if (!this.isGUIInventory(event)) {
+        Player player = Bukkit.getPlayer(event.getView().getPlayer().getUniqueId());
+
+        if (!this.isGUIInventory(event) || !this.isGUI(player)) {
             return; // exit if the inventory is GUI
         }
 
         Integer slotPosition = event.getSlot() + 1; // get the real position of the slot
-        Player player = Bukkit.getPlayer(event.getView().getPlayer().getUniqueId());
         GUIBuilder builder = builders.get(player);
         GUISlot slot = builder.getSlot(slotPosition); // get the slot data
 

--- a/src/main/java/playerquests/client/quest/QuestClient.java
+++ b/src/main/java/playerquests/client/quest/QuestClient.java
@@ -1,30 +1,25 @@
 package playerquests.client.quest;
 
 import java.util.ArrayList; // array list type
-import java.util.HashMap; // hash table map type
-import java.util.HashSet; // hash table set type
+import java.util.HashMap; // hash implementation of map data type
 import java.util.List; // generic list type
-import java.util.Map; // generic map type
-import java.util.Set; // generic set type
-import java.util.stream.Collectors; // translates a stream to data type
+import java.util.Map; // map data type, offers a key-value pair
 
-import org.bukkit.Bukkit; // bukkit api
-import org.bukkit.Particle; // particle effects (FX)
-import org.bukkit.entity.HumanEntity; // represents players and other humanoid entities
+import org.bukkit.Bukkit; // the minecraft server API
+import org.bukkit.Particle;
 import org.bukkit.entity.Player; // represents just players
-import org.bukkit.scheduler.BukkitScheduler; // schedules tasks/code/jobs on plugin
-import org.bukkit.scheduler.BukkitTask; // object for scheduled tasks
+import org.bukkit.scheduler.BukkitScheduler; // for doing actions later and etc
+import org.bukkit.scheduler.BukkitTask; // for particle effects (FX)
 
-import playerquests.Core; // access to singletons
-import playerquests.builder.quest.action.None; // empty quest action
-import playerquests.builder.quest.action.QuestAction; // represents quest actions
+import playerquests.Core;
+import playerquests.builder.quest.action.QuestAction; // quest action
 import playerquests.builder.quest.data.ConnectionsData;
-import playerquests.builder.quest.data.LocationData; // data object containing all location info
+import playerquests.builder.quest.data.LocationData;
+import playerquests.builder.quest.data.StagePath;
 import playerquests.builder.quest.npc.QuestNPC; // represents quest npcs
-import playerquests.builder.quest.stage.QuestStage; // represents quest stages 
 import playerquests.product.Quest; // represents a player quest
-import playerquests.utility.singleton.Database; // where game data is stored
-import playerquests.utility.singleton.QuestRegistry; // where available quests are stored
+import playerquests.utility.singleton.Database; // the preservation/backup store
+import playerquests.utility.singleton.QuestRegistry;
 
 /**
  * Quest tracking and interactions for each player.
@@ -34,42 +29,28 @@ public class QuestClient {
     /**
      * The player who is using this quest client.
      */
-    private HumanEntity player;
-
-    /**
-     * If the user has world effects on.
-     */
-    private Boolean fx;
-
-    /**
-     * The quests available to play (which haven't been started already).
-     */
-    private Map<String, Quest> availableQuests = new HashMap<String, Quest>();
-
-    /**
-     * The entry stage for each quest.
-     */
-    private Map<Quest, QuestStage> entryStages = new HashMap<Quest, QuestStage>();
-
-    /**
-     * The entry action for each entry stage. 
-     */
-    private Map<QuestStage, QuestAction> entryActions = new HashMap<QuestStage, QuestAction>();
-    
-    /**
-     * The NPC associated with each entry action.
-     */
-    private Map<QuestNPC, QuestAction> npcActions = new HashMap<QuestNPC, QuestAction>();
-
-    /**
-     * The particles associated with NPC.
-     */
-    private Map<QuestNPC, BukkitTask> npcParticles = new HashMap<QuestNPC, BukkitTask>();
+    private Player player;
 
     /**
      * Quest diary API for this player.
      */
     private QuestDiary diary;
+
+    /**
+     * The action associated with an NPC.
+     * Helps show an action when interacting with an NPC.
+     */
+    private Map<QuestNPC, QuestAction> actionNPC = new HashMap<QuestNPC, QuestAction>();
+
+    /**
+     * List of the running FX.
+     */
+    private List<BukkitTask> activeFX = new ArrayList<BukkitTask>();
+
+    /**
+     * Used for particle FX loops.
+     */
+    BukkitScheduler scheduler = Bukkit.getServer().getScheduler();
 
     /**
      * Creates a new quest client to act on behalf of a player.
@@ -81,21 +62,14 @@ public class QuestClient {
     public QuestClient(Player player) {
         this.player = player;
 
-        // put player in database (and store the established ID)
-        Integer dbPlayerID = Database.getInstance().addPlayer(player.getUniqueId());
-
-        // create and/or establish quest diary for this player
-        this.diary = new QuestDiary(dbPlayerID);
-
-        // initiate personal quest world state
-        this.showFX(); // visual quest indicators
+        this.diary = new QuestDiary(this);
     }
 
     /**
      * Gets the player who is using the quest client.
      * @return human entity object representing the player
      */
-    public HumanEntity getPlayer() {
+    public Player getPlayer() {
         return player;
     }
 
@@ -103,40 +77,23 @@ public class QuestClient {
      * Add a list of quests for this quest client.
      * @param questList a list of quest products.
      */
-    public void addQuests(ArrayList<Quest> questList) {
-        questList.stream().forEach(quest -> {
-            String questID = quest.getID();
-
-            if (this.availableQuests.containsKey(questID)) {
-                return; // don't continue
-            }
-
-            // put the quests
-            this.availableQuests.put(questID, quest);
+    public void addQuests(List<Quest> questList) {
+        questList.parallelStream().forEach((quest) -> {
+            this.diary.addQuest(quest);
         });
 
-        this.update();
+        this.update(); // update what the player sees
     }
 
     /**
      * Adds the quest effects in the world for this quester.
      */
     public void showFX() {
-        this.fx = true;
+        this.hideFX(); // ensure old are removed before showing
 
-        BukkitScheduler scheduler = Bukkit.getServer().getScheduler();
-        Player player = Bukkit.getServer().getPlayer(this.player.getUniqueId());
-
-        // remove particles from quest NPCs by the quests which
-        // are no longer 'available'
-        this.npcParticles.keySet().stream()
-            .filter(quest -> !this.availableQuests.containsKey(quest.getID()))
-            .forEach(quest -> scheduler.cancelTask(this.npcParticles.get(quest).getTaskId()));
-
-        // add interact sparkle to each starting/entry-point NPC
-        this.npcActions.keySet().stream().forEach(npc -> {
+        this.actionNPC.keySet().stream().forEach((npc) -> {
+            // create particle effect
             LocationData location = npc.getLocation();
-
             BukkitTask task = scheduler.runTaskTimer(Core.getPlugin(), () -> {
                 player.spawnParticle(
                     Particle.WAX_ON,
@@ -147,7 +104,8 @@ public class QuestClient {
                 );
             }, 0, 20);
 
-            npcParticles.put(npc, task);
+            // store a reference to this effect for cancelling
+            activeFX.add(task);
         });
     }
 
@@ -155,89 +113,47 @@ public class QuestClient {
      * Removes the quest effects from the world for this quester.
      */
     public void hideFX() {
-        BukkitScheduler scheduler = Bukkit.getServer().getScheduler();
-        this.fx = false;
-
-        // remove particles already in world
-        this.npcParticles.values().stream().forEach(task -> {
+        // get all active effects and cancel
+        this.activeFX.stream().forEach((task) -> {
+            // cancel FX loops
             scheduler.cancelTask(task.getTaskId());
         });
     }
 
     /**
-     * Refresh all values.
-     * These are called 'helper maps' here,
+     * Update what the player sees.
      */
     public void update() {
-        // clear the helper maps
-        entryStages.clear();
-        entryActions.clear();
-        npcActions.clear();
+        // clear action-npc-associations for the refresh! (good for if a quest is deleted)
+        this.actionNPC.clear();
 
-        // create a set for local available quests and questregistry available quests
-        List<Quest> registryList = new ArrayList<>(QuestRegistry.getInstance().getAllQuests().values()); // current all quests
-        List<Quest> localList =  new ArrayList<>(this.availableQuests.values()); // previous all quests
+        // NPC magic! (assigning an action to an npc based on progress in quest)
+        // get each quest progress
+        Map<QuestNPC, QuestAction> actionNPCsLocal = new HashMap<>(); 
+        this.diary.getQuestProgress().forEach((quest, connections) -> {
 
-        // add quests to parse through to create a sort of index powered by the 'helper maps'
-        Set<Quest> questSet = new HashSet<Quest>();
-        questSet.addAll(registryList);
-        questSet.addAll(localList);
+            // get the action we are up to in this quest to..
+            QuestAction action = this.diary.getAction(quest);
 
-        // update 'helper maps'
-        questSet.stream().forEach(quest -> {
-            // don't continue if quest is invalid
-            if (!quest.isValid()) {
-                return;
-            }
-
-            // don't continue if quest isn't toggled
-            if (!quest.isToggled()) {
-                return;
-            }
-
-            // get this quest id (to check available quests against the diary)
-            String questID = quest.getID();
-
-            // get our current position in quest (curr, prev)
-            ConnectionsData questProgress = this.diary.getQuestProgress(questID);
-
-            // the action/stage that is todo
-            QuestAction action;
-            QuestStage stage;
-            
-            if (questProgress != null) { // (if user has progressed in this quest)
-                // get the 'todo' action/stage
-                action = this.diary.getAction(questID);
-                stage = this.diary.getStage(questID);
-
-            } else { // (if no user progress logged for this quest)
-                // get the 'entry point' action/stage
-                stage = quest.getStages().get(quest.getEntry()); // the first stage to look at when starting a quest
-                action = stage.getEntryPoint(); // the first action to look at when starting a quest
-
-                // add quest to diary
-                this.diary.addQuest(quest.getID());
-            }
-
-            // queue up the action/stage
-            this.entryStages.put(quest, stage);
-            this.entryActions.put(stage, action);
-
-            // put the NPC from entry action (if is valid)
+            // ..get the npc
             QuestNPC npc = action.getNPC();
-            if (npc != null || action.getClass() != None.class) {
-                this.npcActions.put(npc, action);
+
+            // don't continue if no npc matched to this action
+            if (npc == null) {
+                return;
             }
+            
+            // ..and submit the 'action <-> NPC' association
+            actionNPCsLocal.put(
+                npc,
+                action
+            );
         });
 
-        // merge previous and current map of all quests, as main list of quests available to this quester
-        this.availableQuests = questSet.stream()
-            .collect(Collectors.toMap(quest -> quest.getID(), quest -> quest));
+        // submit the NPCs we found progress for
+        this.actionNPC.putAll(actionNPCsLocal);
 
-        // show particles indicating NPCs
-        if (this.fx) {
-            this.showFX();
-        }
+        this.showFX();
     }
 
     /**
@@ -245,9 +161,9 @@ public class QuestClient {
      * @param quest the quest to remove
      */
     public void removeQuest(Quest quest) {
-        this.availableQuests.remove(quest.getID());
+        this.diary.removeQuest(quest);
 
-        this.update();
+        this.update(); // reflect changes
     }
 
     /**
@@ -255,21 +171,21 @@ public class QuestClient {
      * @param npc the npc to interact with the quest through
      */
     public void interact(QuestNPC npc) {
-        QuestAction action = this.npcActions.get(npc);
-        Quest quest = npc.getQuest();
+        // Find the action associated with this npc in a helper map
+        Quest quest = QuestRegistry.getInstance().getQuest(npc.getQuest().getID()); // inefficient way, but npc.getQuest() was returning bad data
+        QuestAction action = this.actionNPC.get(npc);
 
-        // don't continue if there is no action
-        // for this interaction
-        if (action == null) {
+        // Don't continue if there is no quest or action for this interaction
+        if (action == null || quest == null) {
             return;
         }
 
-        // prep interaction/next step vars
-        String next_step = action.getConnections().getNext(); // could be action_?, stage_?
-        ConnectionsData diaryConnections = this.diary.getQuestProgress(quest.getID()); // read current position in quest
+        // Prepare interaction/next step vars
+        StagePath next_step = action.getConnections().getNext(); // could be action_?, stage_?
+        ConnectionsData diaryConnections = this.diary.getQuestProgress(quest); // read current position in quest
 
         if (diaryConnections == null) { // if no progress for this quest found
-            diaryConnections = quest.getStages().get(quest.getEntry()).getConnections(); // get quest entry point position
+            diaryConnections = quest.getStages().get(quest.getEntry().getStage()).getConnections(); // get quest entry point position
         }
 
         // move forward through connections
@@ -279,17 +195,23 @@ public class QuestClient {
             updatedConnections.setCurr(next_step);
 
             // update the diary
-            this.diary.setQuestProgress(quest.getID(), updatedConnections);
+            this.diary.setQuestProgress(quest, updatedConnections);
+
+            // update the db for preservation sake
+            Database.getInstance().setDiaryQuest(this.diary, quest, updatedConnections);
 
             // remove NPCs pending interaction marker/sparkle
-            npcActions.remove(npc);
+            this.actionNPC.remove(npc);
 
             // update quest state
             this.update();
         }
-        
-        // execute the interaction
-        action.Run(this); // test, less complicated? also remove me
+
+        // Do the action
+        action.Run(this);
+
+        // Update what the player sees
+        this.update();
     }
 
     /**

--- a/src/main/java/playerquests/utility/ChatUtils.java
+++ b/src/main/java/playerquests/utility/ChatUtils.java
@@ -125,6 +125,15 @@ public class ChatUtils {
         }
 
         /**
+         * For editing the base message.
+         * @param the potatos of what the message is
+         */
+        public MessageBuilder content(String baseMessage) {
+            this.content = baseMessage;
+            return this;
+        }
+
+        /**
          * For adding a message type
          * @param messageType the MessageType enum
          * @return the MessageBuilder to chain next function.

--- a/src/main/java/playerquests/utility/FileUtils.java
+++ b/src/main/java/playerquests/utility/FileUtils.java
@@ -64,4 +64,16 @@ public class FileUtils {
             throw new IOException("Could not delete the '" + filename + "' file.", e);
         }
     }
+
+    /**
+     * Checks if a file at the specified path exists.
+     * @param filename relative child path + filename
+     * @throws IOException when the file cannot be read
+     * @return if the file exists
+     */
+    public static Boolean check(String filename) throws IOException {
+        Path fullPath = Paths.get(Core.getPlugin().getDataFolder() + "/" + filename);
+
+        return Files.exists(fullPath);
+    }
 }

--- a/src/main/java/playerquests/utility/MigrationUtils.java
+++ b/src/main/java/playerquests/utility/MigrationUtils.java
@@ -1,0 +1,93 @@
+package playerquests.utility;
+
+/**
+ * Provides the changes for each version.
+ * For example: the changes to the database.
+ */
+public class MigrationUtils {
+    // Get migration query for version 0.4
+    public static String dbV0_4() {
+        return "ALTER TABLE quests ADD COLUMN toggled TEXT DEFAULT true;";
+    }
+
+    // Get migration query for version 0.5
+    public static String dbV0_5() {
+        throw new IllegalArgumentException("No migration query for version v0.5.1");
+    }
+
+    // Get migration query for version 0.5.1
+    public static String dbV0_5_1() {
+        return """
+            -- Begin a transaction to ensure all operations are atomic
+            BEGIN TRANSACTION;
+            
+            -- Drop temporary tables if they exist
+            DROP TABLE IF EXISTS temp_diary_quests;
+            DROP TABLE IF EXISTS temp_diaries;
+            DROP TABLE IF EXISTS temp_quests;
+            DROP TABLE IF EXISTS temp_players;
+            
+            -- Create temporary tables for migration
+            CREATE TABLE temp_players (
+                uuid TEXT PRIMARY KEY NOT NULL
+            );
+            
+            CREATE TABLE temp_quests (
+                id TEXT PRIMARY KEY NOT NULL
+            );
+            
+            CREATE TABLE temp_diaries (
+                id TEXT PRIMARY KEY NOT NULL,
+                player TEXT UNIQUE,
+                FOREIGN KEY (player) REFERENCES temp_players(uuid)
+            );
+            
+            CREATE TABLE temp_diary_quests (
+                id TEXT PRIMARY KEY NOT NULL,
+                stage TEXT NOT NULL,
+                action TEXT,
+                quest TEXT,
+                diary TEXT,
+                FOREIGN KEY (quest) REFERENCES temp_quests(id),
+                FOREIGN KEY (diary) REFERENCES temp_diaries(id)
+            );
+            
+            -- Migrate data from old tables to temporary tables
+            INSERT INTO temp_players (uuid)
+            SELECT uuid FROM players;
+            
+            INSERT INTO temp_quests (id)
+            SELECT id FROM quests;
+            
+            INSERT INTO temp_diaries (id, player)
+            SELECT 'diary_' || p.uuid, p.uuid
+            FROM diaries AS d
+            JOIN players AS p ON d.player = p.id;
+            
+            INSERT INTO temp_diary_quests (id, stage, action, quest, diary)
+            SELECT dq.id, dq.stage, dq.action, dq.quest, 'diary_' || p.uuid
+            FROM diary_quests AS dq
+            JOIN diaries AS d ON dq.diary = d.id
+            JOIN players AS p ON d.player = p.id;
+            
+            -- Drop old tables
+            DROP TABLE IF EXISTS diary_quests;
+            DROP TABLE IF EXISTS diaries;
+            DROP TABLE IF EXISTS quests;
+            DROP TABLE IF EXISTS players;
+            
+            -- Rename temporary tables to match new schema
+            ALTER TABLE temp_players RENAME TO players;
+            ALTER TABLE temp_quests RENAME TO quests;
+            ALTER TABLE temp_diaries RENAME TO diaries;
+            ALTER TABLE temp_diary_quests RENAME TO diary_quests;
+            
+            -- Remove unused sequence tracking (next increments)
+            DELETE FROM sqlite_sequence WHERE name = 'diaries';
+            DELETE FROM sqlite_sequence WHERE name = 'players';
+            
+            -- Commit the transaction if everything is successful
+            COMMIT;
+        """;
+    }
+}

--- a/src/main/java/playerquests/utility/listener/ServerListener.java
+++ b/src/main/java/playerquests/utility/listener/ServerListener.java
@@ -1,68 +1,177 @@
 package playerquests.utility.listener;
 
-import java.io.File;
-import java.io.IOException; // thrown when a file operation fails, like reading
+import java.io.File; // Represents a file in the filesystem
+import java.io.IOException; // Thrown when a file operation fails, such as reading
+import java.nio.file.*; // Provides classes and methods for file I/O operations
+import java.util.HashSet; // Implements a set that does not allow duplicate elements
+import java.util.Set; // Interface for collections that do not allow duplicate elements
+import java.util.stream.Stream; // Provides a sequence of elements supporting sequential and parallel aggregate operations
 
-import org.bukkit.Bukkit; // bukkit API
-import org.bukkit.event.EventHandler; // indicate that a method is wanting to handle an event
-import org.bukkit.event.Listener; // registering listening to Bukkit in-game events
-import org.bukkit.event.server.ServerLoadEvent; // when a server is reloaded or started up
+import org.bukkit.Bukkit; // Bukkit API for interacting with the server
+import org.bukkit.event.EventHandler; // Annotation to mark methods as event handlers
+import org.bukkit.event.Listener; // Interface for registering event listeners
+import org.bukkit.event.server.ServerLoadEvent; // Event triggered when the server is loaded or reloaded
 
-import com.fasterxml.jackson.core.JsonProcessingException; // thrown when json cannot be processed
-import com.fasterxml.jackson.databind.JsonMappingException; // thrown when json is malformed
+import com.fasterxml.jackson.core.JsonProcessingException; // Thrown when JSON cannot be processed
+import com.fasterxml.jackson.databind.JsonMappingException; // Thrown when JSON is malformed
 
-import playerquests.Core; // accessing plugin singeltons
-import playerquests.client.quest.QuestClient; // represents a quest player/quest tracking
-import playerquests.product.Quest; // quest product class
-import playerquests.utility.ChatUtils; // for sending cute-ified messages
-import playerquests.utility.ChatUtils.MessageTarget;
-import playerquests.utility.ChatUtils.MessageType;
-import playerquests.utility.FileUtils; // helpers for working with files
-import playerquests.utility.singleton.Database; // API for game persistent data
-import playerquests.utility.singleton.QuestRegistry; // place where quests are stored
+import playerquests.Core; // Access to plugin singleton
+import playerquests.client.quest.QuestClient; // Represents a quest client for player quest tracking
+import playerquests.product.Quest; // Represents a quest product class
+import playerquests.utility.ChatUtils; // Utility for sending chat messages
+import playerquests.utility.ChatUtils.MessageStyle; // Enum for different message styles
+import playerquests.utility.ChatUtils.MessageTarget; // Enum for different message targets
+import playerquests.utility.ChatUtils.MessageType; // Enum for different message types
+import playerquests.utility.FileUtils; // Utility for file operations
+import playerquests.utility.singleton.Database; // API for managing persistent game data
+import playerquests.utility.singleton.PlayerQuests;
+import playerquests.utility.singleton.QuestRegistry; // Registry for storing quests
 
 /**
- * Listens out for all server-related events to inform 
- * where needed.
+ * This class listens for server-related events and filesystem changes,
+ * such as server load or reload, and performs necessary actions such as 
+ * initializing data, processing quests, and setting up quest clients.
  */
 public class ServerListener implements Listener {
 
+    private WatchService watchService;
+    private Thread watchThread;
+
+    /**
+     * Constructor for the ServerListener class. Registers this listener
+     * with the Bukkit event system.
+     */
     public ServerListener() {
         Bukkit.getPluginManager().registerEvents(this, Core.getPlugin());
     }
 
     /**
-     * Ran whenever the server is started or reloaded.
-     * Use [return value].onFinish(() -> {}) for callback.
-     * @param event the LoadType
-     * @return the ServerListener itself
+     * Handles the ServerLoadEvent, which is triggered when the server is
+     * started or reloaded. Initializes necessary directories, processes quest
+     * templates, and sets up quest clients for online players. Also starts
+     * the file watcher service if it is not already running.
+     * 
+     * @param event the ServerLoadEvent that contains information about the server load
      */
     @EventHandler
-    public ServerListener onLoad(ServerLoadEvent event) {
-        // create plugin folder if it doesn't exist
-        File f = new File(Core.getPlugin().getDataFolder() + "/");
-        if (!f.exists()) {
-            f.mkdir();
-            ChatUtils.message("Welcome!")
-                .target(MessageTarget.WORLD)
-                .type(MessageType.NOTIF)
+    public void onLoad(ServerLoadEvent event) {
+        createDirectories(); // ensure dirs are created
+        initializeDatabase(); // init db
+
+        // Ensure quest processing runs on the main thread
+        Bukkit.getScheduler().runTask(Core.getPlugin(), () -> {
+            processQuests();
+            createQuestClients();
+        });
+
+        startWatchService(); // start fs watching
+    }
+    
+    /**
+     * Called when the server is being disabled (including when reloaded).
+     * Designed to handle onDisable from the Core (JavaPlugin).
+     * 
+     * This method is used to clean up resources, stop ongoing tasks, and 
+     * perform other necessary shutdown procedures.
+     */
+    public void onDisable() {
+        // Cancel all tasks scheduled by this plugin to prevent overlaps
+        Bukkit.getServer().getScheduler().cancelTasks(Core.getPlugin());
+
+        // Close/clear the plugin
+        PlayerQuests.getInstance().clear();
+
+        // Stop the WatchService used for monitoring file changes.
+        // This ensures that no further file watching occurs after 
+        // the plugin is disabled, and resources related to file 
+        // monitoring are properly released.
+        stopWatchService();        
+    }
+
+    /**
+     * Creates necessary directories for the plugin if they do not already exist.
+     */
+    private void createDirectories() {
+        File dataFolder = new File(Core.getPlugin().getDataFolder() + "/");
+        if (!dataFolder.exists()) {
+            dataFolder.mkdir();
+            sendWelcomeMessage();
+        }
+
+        File templatesFolder = new File(Core.getPlugin().getDataFolder() + "/quest/templates");
+        if (!templatesFolder.exists()) {
+            templatesFolder.mkdirs();
+        }
+
+        Core.getPlugin().saveResource("quest/templates/beans-tester-bonus.json", true);
+    }
+
+    /**
+     * Sends a welcome message to the world when the plugin folder is created.
+     */
+    private void sendWelcomeMessage() {
+        ChatUtils.message("Welcome!")
+            .target(MessageTarget.WORLD)
+            .type(MessageType.NOTIF)
+            .send();
+    }
+
+    /**
+     * Initializes the database and handles any necessary setup.
+     */
+    private void initializeDatabase() {
+        Database.getInstance().init();
+    }
+
+    /**
+     * Processes quests from both the database and file system, and submits them to the quest registry.
+     */
+    private void processQuests() {
+        File questsDir = new File(Core.getPlugin().getDataFolder(), "/quest/templates");
+        Set<String> allQuests = new HashSet<>();
+        
+        // add from db
+        allQuests.addAll(Database.getInstance().getAllQuests());
+
+        // add from fs
+        try (Stream<Path> paths = Files.walk(questsDir.toPath())) {
+            paths.filter(Files::isRegularFile) // Filter to include only files
+                .filter(path -> path.toString().endsWith(".json")) // Include only JSON files
+                .forEach(path -> {
+                    String questName = getQuestName(path);
+                    allQuests.add(questName);
+                });
+        } catch (IOException e) {
+            ChatUtils.message("Could not process the quests template directory/path :(. " + e)
+                .target(MessageTarget.CONSOLE)
+                .style(MessageStyle.PLAIN)
+                .type(MessageType.ERROR)
                 .send();
         }
 
-        // Save the demo quest to the server
-        Core.getPlugin().saveResource("quest/templates/beans-tester-bonus.json", true);
+        submitQuestsToRegistry(allQuests);
+    }
 
-        // initialise the database
-        Database.getInstance().init();
+    private String getQuestName(Path path) {
+        String[] questNameParts = path.toString()
+            .replace(".json", "")
+            .split("/templates/");
 
-        if (event.getEventName().equals("RELOAD")) {
-            Bukkit.getServer().getScheduler().cancelTasks(Core.getPlugin());
-            QuestRegistry.getInstance().clear();
+        if (questNameParts.length < 1) {
+            return null;
         }
 
-        // try to submit database quests to quest registry
-        Database.getInstance().getAllQuests().forEach(id -> {
-            Boolean err = true; // assume errored (avoids repeating it for each catch)
+        return questNameParts[1];
+    }
+
+    /**
+     * Submits quests to the quest registry and handles any errors.
+     * 
+     * @param quests the set of quest IDs to process
+     */
+    private void submitQuestsToRegistry(Set<String> quests) {
+        quests.forEach(id -> {
+            boolean errorOccurred = true; // Assume an error occurred initially
             
             try {
                 Quest newQuest = Quest.fromTemplateString(FileUtils.get("quest/templates/" + id + ".json"));
@@ -72,43 +181,133 @@ public class ServerListener implements Listener {
                 }
 
                 QuestRegistry.getInstance().submit(newQuest);
-                err = false;
+                errorOccurred = false;
 
             } catch (JsonMappingException e) {
-                System.err.println("Could not accurately map template: " + id + ", to the Quest object. " + e);
+                System.err.println("Could not map template: " + id + " to the Quest object. " + e);
             } catch (JsonProcessingException e) {
-                System.err.println("JSON in template: " + id + ", is malformed. " + e);
+                System.err.println("JSON in template: " + id + " is malformed. " + e);
             } catch (IOException e) {
                 System.err.println("Could not read file: " + id + ".json. " + e);
             }
 
-            // remove the quest if unreadable
-            if (err) {
-                Database.removeQuest(id);
+            // Remove the quest from the database if an error occurred
+            if (errorOccurred) {
+                Database.getInstance().removeQuest(id);
             }
         });
 
-        System.out.println("[PlayerQuests] Finished loading database quests into registry: " + QuestRegistry.getInstance().getAllQuests().keySet());
-
-        // for every user, create a quest client and add it to registry.
-        // this enables a player to interact with and track quests.
-        Bukkit.getServer().getOnlinePlayers().stream()
-            .forEach(player -> {
-                QuestClient quester = new QuestClient(player);
-                QuestRegistry.getInstance().addQuester(quester);
-            });
-
-        // function chaining reasons:
-        return this;
+        ChatUtils.message("Finished loading database quests into registry: " + quests)
+            .target(MessageTarget.CONSOLE)
+            .style(MessageStyle.PLAIN)
+            .type(MessageType.NOTIF)
+            .send();
     }
 
     /**
-     * Sets code to be executed when the function is finished.
-     * @param runnable the code to run when the function completes
+     * Creates a quest client for each online player and adds it to the quest registry.
      */
-    public void onFinish(Runnable runnable) {
-        if (runnable != null) {
-            runnable.run();
+    private void createQuestClients() {
+        Bukkit.getServer().getOnlinePlayers().forEach(player -> {
+            QuestClient quester = new QuestClient(player);
+            QuestRegistry.getInstance().addQuester(quester);
+        });
+    }
+
+    /**
+     * Starts the WatchService to monitor the quest/templates directory for changes.
+     * This service watches for file creation, deletion, and modification events.
+     */
+    private void startWatchService() {
+        try {
+            watchService = FileSystems.getDefault().newWatchService();
+            Path questTemplatesPath = Paths.get(Core.getPlugin().getDataFolder() + "/quest/templates");
+            questTemplatesPath.register(watchService, 
+                StandardWatchEventKinds.ENTRY_CREATE, 
+                StandardWatchEventKinds.ENTRY_DELETE, 
+                StandardWatchEventKinds.ENTRY_MODIFY
+            );
+
+            watchThread = new Thread(() -> {
+                while (!Thread.currentThread().isInterrupted()) {
+                    WatchKey key;
+                    try {
+                        key = watchService.take();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        return;
+                    }   
+
+                    for (WatchEvent<?> event : key.pollEvents()) {
+                        WatchEvent.Kind<?> kind = event.kind();
+                    
+                        // This key is no longer valid, break out of the loop
+                        if (kind == StandardWatchEventKinds.OVERFLOW) {
+                            continue;
+                        }
+                    
+                        // Ensure the event is of type WatchEvent<Path>
+                        @SuppressWarnings("unchecked")
+                        WatchEvent<Path> ev = (WatchEvent<Path>) event;
+                        Path filename = ev.context();
+
+                        // Don't panic, let's handle deletion
+                        if (kind == StandardWatchEventKinds.ENTRY_DELETE) {
+                            System.out.println("figure out if an important file was deleted here");
+                        }
+                    
+                        // Handle changes to quest templates
+                        if (filename.toString().endsWith(".json")) {
+                            String questName = filename.toString().replace(".json", ""); // strip '.json' from the quest ID/filename
+                            QuestRegistry questRegistry = Core.getQuestRegistry(); // get the tracking of instances of the quests in the plugin
+
+                            if (questName == null) {
+                                return;
+                            }
+
+                            switch (kind.name()) {
+                                case "ENTRY_CREATE":
+                                    submitQuestsToRegistry(new HashSet<>(Set.of(questName))); // submit the quest systematically
+                                    break;
+                                case "ENTRY_DELETE":
+                                    questRegistry.remove(
+                                        questRegistry.getQuest(questName) // find the quest object
+                                    ); // delete it systematically
+                                    break;
+                                default:
+                                    break;
+                            }
+                        }
+                    }
+
+                    // Reset the key -- this step is critical if you want to receive further watch events.
+                    boolean valid = key.reset();
+                    if (!valid) {
+                        break;
+                    }
+                }
+            });
+            watchThread.start();
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Stops the WatchService and interrupts the watch thread.
+     * Cleans up resources used by the WatchService.
+     */
+    private void stopWatchService() {
+        if (watchService != null) {
+            watchThread.interrupt();
+            try {
+                watchService.close();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+            watchService = null;
+            watchThread = null;
         }
     }
 }

--- a/src/main/java/playerquests/utility/singleton/Database.java
+++ b/src/main/java/playerquests/utility/singleton/Database.java
@@ -1,8 +1,13 @@
 package playerquests.utility.singleton;
 
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.sql.Connection; // object describing connection to a database
@@ -12,54 +17,89 @@ import java.sql.ResultSet; // represents SQL results
 import java.sql.SQLException; // thrown when a database operation fails
 import java.sql.Statement; // represents SQL statements
 import java.util.ArrayList; // array list type
+import java.util.HashMap;
 import java.util.List; // generic list type
+import java.util.Map;
 import java.util.UUID; // how users are identified
 
 import org.apache.maven.model.Model;
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.bukkit.Bukkit; // the Bukkit API
+import org.bukkit.entity.Player;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import playerquests.Core;
+import playerquests.builder.quest.action.QuestAction;
+import playerquests.builder.quest.data.ConnectionsData;
+import playerquests.builder.quest.data.StagePath;
+import playerquests.builder.quest.stage.QuestStage;
+import playerquests.client.quest.QuestDiary;
 import playerquests.product.Quest;
 import playerquests.utility.ChatUtils;
+import playerquests.utility.MigrationUtils;
+import playerquests.utility.ChatUtils.MessageBuilder;
+import playerquests.utility.ChatUtils.MessageStyle;
 import playerquests.utility.ChatUtils.MessageTarget;
 import playerquests.utility.ChatUtils.MessageType;
 
 /**
- * API representing and providing access to the game database.
- * This when instantiated, creates and/or opens the game database.
- */
+* API representing and providing access to the game database.
+* This when instantiated, creates and/or opens the game database.
+*/
+// TODO: unrealtime-ify the database use-case/move all database things to Database, and synchronise to one thread (use transaction probs, they seem to handle concurrency)
+// TODO: ditch using id for players table, use uuid as primary key
 public class Database {
-
+    
     /**
-     * The singleton instance of this Database class.
-     */
+    * The singleton instance of this Database class.
+    */
     private static Database instance = new Database();
-
+    
     /**
-     * The connection to the database.
-     */
+    * The connection to the database.
+    */
     private static Connection connection;
     
     /**
-     * Database singleton should not be instantiated.
-     * Use Database.getInstance().
-     */
+    * Database singleton should not be instantiated.
+    * Use Database.getInstance().
+    */
     private Database() {}
-
-    /**
-     * Creates tables if they do not already exist.
-     */
-    public Database init() {
-        String version = "0.0";
-        String version_db = Database.getPluginVersion();
-
+    
+    public static Database getInstance() {
+        return instance;
+    }
+    
+    // Synchronous method to get a connection
+    private synchronized Connection getConnection() {
+        try {
+            if (connection != null && !connection.isClosed()) {
+                return connection;
+            }
+        } catch (SQLException e) {
+            System.err.println("Could not check if existing connection was closed: " + e.getMessage());
+        }
+        
+        try {
+            connection = DriverManager.getConnection("jdbc:sqlite:plugins/PlayerQuests/playerquests.db");
+            return connection;
+        } catch (SQLException e) {
+            System.err.println("Could not connect to or create database: " + e.getMessage());
+            return null;
+        }
+    }
+    
+    public synchronized Database init() {
+        String dbVersion = getPluginVersion();
+        String version = "0.0"; // default version
+        
         try (InputStream inputStream = getClass().getResourceAsStream("/META-INF/maven/moe.sammypanda/playerquests/pom.xml")) {
             if (inputStream != null) {
                 MavenXpp3Reader reader = new MavenXpp3Reader();
                 Model model = reader.read(new InputStreamReader(inputStream));
-
-                // get the actual version from the POM
                 version = model.getVersion();
             } else {
                 System.err.println("Error: Resource not found.");
@@ -67,51 +107,42 @@ public class Database {
         } catch (IOException | XmlPullParserException e) {
             System.err.println("Error reading pom.xml: " + e.getMessage());
         }
+        
+        try (Connection connection = getConnection();
+            Statement statement = connection.createStatement()) {
 
-        try {
-            Statement statement = getConnection().createStatement();
-
-            // Create plugin table (for storing info)
             String pluginTableSQL = "CREATE TABLE IF NOT EXISTS plugin ("
-            + "plugin TEXT PRIMARY KEY,"    
+            + "plugin TEXT PRIMARY KEY,"
             + "version TEXT NOT NULL,"
             + "CONSTRAINT single_row_constraint UNIQUE (plugin));";
             statement.execute(pluginTableSQL);
-
-            // Create players table
+            
             String playersTableSQL = "CREATE TABLE IF NOT EXISTS players ("
-                + "id INTEGER PRIMARY KEY AUTOINCREMENT,"
-                + "uuid TEXT NOT NULL);";
+            + "uuid TEXT PRIMARY KEY NOT NULL);";
             statement.execute(playersTableSQL);
-
-            // Create quests table
+            
             String questsTableSQL = "CREATE TABLE IF NOT EXISTS quests ("
-                + "id TEXT PRIMARY KEY,"
-                + "toggled BOOLEAN NOT NULL DEFAULT TRUE);";
+            + "id TEXT PRIMARY KEY,"
+            + "toggled BOOLEAN NOT NULL DEFAULT TRUE);";
             statement.execute(questsTableSQL);
-
-            // Create diaries table
+            
             String diariesTableSQL = "CREATE TABLE IF NOT EXISTS diaries ("
-                + "id INTEGER PRIMARY KEY AUTOINCREMENT,"
-                + "player INTEGER UNIQUE,"
-                + "FOREIGN KEY (player) REFERENCES players(id));";
+            + "id TEXT PRIMARY KEY NOT NULL,"
+            + "player TEXT UNIQUE,"
+            + "FOREIGN KEY (player) REFERENCES players(uuid));";
             statement.execute(diariesTableSQL);
-
-            // Create diary_quests table
+            
             String diary_questsTableSQL = "CREATE TABLE IF NOT EXISTS diary_quests ("
-                + "id TEXT PRIMARY KEY,"
-                + "stage TEXT NOT NULL,"
-                + "action TEXT,"
-                + "quest TEXT,"
-                + "diary INTEGER,"
-                + "FOREIGN KEY (quest) REFERENCES quests(id)"
-                + "FOREIGN KEY (diary) REFERENCES diaries(id));";
+            + "id TEXT PRIMARY KEY,"
+            + "stage TEXT NOT NULL,"
+            + "action TEXT,"
+            + "quest TEXT,"
+            + "diary TEXT,"
+            + "FOREIGN KEY (quest) REFERENCES quests(id)"
+            + "FOREIGN KEY (diary) REFERENCES diaries(id));";
             statement.execute(diary_questsTableSQL);
-
-            statement.close();
-            getConnection().close();
-
-            Database.migrate(version, version_db);
+            
+            migrate(version, dbVersion);
 
         } catch (SQLException e) {
             System.err.println("Could not initialise the database: " + e.getMessage());
@@ -119,353 +150,390 @@ public class Database {
 
         return this;
     }
+    
+    private synchronized void migrate(String version, String version_db) {
+        // Check if there is a new version
+        MessageBuilder alert = new MessageBuilder("Could not retrieve latest version. Maybe you're offline or GitHub is unavailable?")
+            .style(MessageStyle.PRETTY)
+            .target(MessageTarget.WORLD)
+            .type(MessageType.WARN);
+        try {
+            URL url = new URI("https://api.github.com/repos/sammypanda/mcje-playerquests-plugin/releases").toURL();
+            HttpURLConnection con = (HttpURLConnection) url.openConnection();
+            con.setRequestMethod("GET");
 
-    private static void migrate(String version, String version_db) {
+            // Read the entire input stream into a single string
+            String content;
+            try (BufferedReader in = new BufferedReader(new InputStreamReader(con.getInputStream()))) {
+                content = in
+                    .lines()
+                    .reduce("", (accumulator, actual) -> accumulator + actual);
+            }
+
+            // Parse the JSON and print the desired value
+            JsonNode tree = new ObjectMapper().readTree(content);
+            String latest = tree.findValue("tag_name").textValue(); // get latest tag_name (for example "v0.5")
+
+            // Alert if latest version is different to current
+            // (this will happen on snapshots too, but the compute for this edge case doesn't seem worthwhile)
+            if ("v"+version != latest) {
+                alert.content("A new release is available! " + latest)
+                    .send();
+            }
+        } catch (URISyntaxException | IOException e) {
+            alert.send();
+        }
+
+        // don't migrate if no version change 
+        // (pom version same as db version)
         if (version_db.equals(version)) {
-            // Nothing to migrate/update
             return;
         }
+        
+        try (Connection connection = getConnection();
+            Statement statement = connection.createStatement()) {
 
-        if (version_db.equals("0.0")) {
-            try {
-                // Insert PlayerQuests version from plugin table
-                String setPluginSQL = "INSERT INTO plugin (plugin, version) VALUES (?, ?);";
-                PreparedStatement preparedStatement = getConnection().prepareStatement(setPluginSQL);
-                preparedStatement.setString(1, "PlayerQuests"); // parameterIndex starts at 1
-                preparedStatement.setString(2, version);
-                preparedStatement.execute();
-                System.out.println("Migrated/patched database: added plugin database table");
-
-                getConnection().close();
-            } catch (SQLException e) {
-                System.err.println("Could not insert plugin data to db " + e.getMessage());
-            }
-        }
-
-        try {
-            Statement statement = getConnection().createStatement();
-
+            StringBuilder query = new StringBuilder();
+            
             switch (version) {
+                case "0.5.1":
+                    query.append(MigrationUtils.dbV0_5_1());
+                case "0.5":
                 case "0.4":
-                    String addToggledSQL = "ALTER TABLE quests ADD COLUMN toggled TEXT DEFAULT true;";
-                    statement.execute(addToggledSQL);
-                    break;
+                    query.append(MigrationUtils.dbV0_4());
             }
+
+            statement.executeUpdate(query.toString());
+
         } catch (SQLException e) {
             System.err.println("Could not patch/migrate database " + e.getMessage());
         }
-
-        // update plugin version in db
-        Database.setPluginVersion(version);
+        
+        // Update plugin version in db
+        setPluginVersion(version);
         ChatUtils.message("You're on v" + version + "! https://sammypanda.moe/docs/playerquests/v" + version)
             .target(MessageTarget.WORLD)
             .type(MessageType.NOTIF)
             .send();
     }
-
-    public static String getPluginVersion() {
+    
+    public synchronized String getPluginVersion() {
         if (!Files.exists(Paths.get("plugins/PlayerQuests/playerquests.db"))) {
-            // Don't try to continue with fetching version if no database
             return "0.0";
         }
+        
+        try (Connection connection = getConnection();
+            PreparedStatement statement = connection.prepareStatement("SELECT version FROM plugin WHERE plugin = 'PlayerQuests';")) {
 
-        try {
-            Statement statement = getConnection().createStatement();
-
-            // Get PlayerQuests version from plugin table
-            String getVersionSQL = "SELECT version FROM plugin WHERE plugin = 'PlayerQuests';";
-            ResultSet results = statement.executeQuery(getVersionSQL);
+            ResultSet results = statement.executeQuery();
             String version = results.getString("version");
 
-            getConnection().close();
             return version;
-        
         } catch (SQLException e) {
             System.err.println("Could not find the quest version in the db " + e.getMessage());
             return "0.0";
         }
     }
+    
+    private synchronized void setPluginVersion(String version) {
+        try (Connection connection = getConnection();
+            PreparedStatement preparedStatement = connection.prepareStatement("""
+                INSERT INTO plugin (plugin, version)
+                VALUES ('PlayerQuests', ?)
+                ON CONFLICT(plugin)
+                DO UPDATE SET version = excluded.version;
+            """)) {
 
-    private static void setPluginVersion(String version) {
-        try {
-            // Set PlayerQuests version in plugin table
-            String setVersionSQL = "UPDATE plugin SET version = ? WHERE plugin = 'PlayerQuests';";
-            PreparedStatement preparedStatement = getConnection().prepareStatement(setVersionSQL);
             preparedStatement.setString(1, version);
+
             preparedStatement.execute();
 
-            getConnection().close();
+        } catch (SQLException e) {
+            System.err.println("Could not insert or set the quest version in the db " + e.getMessage());
+        }
+    }
+
+    /**
+     * Adds a new player to the database with the specified UUID.
+     * 
+     * This method inserts a new record into the `players` table of the database using the provided
+     * UUID. The UUID is converted to a string and stored in the `uuid` column. The SQL `INSERT` statement
+     * is used along with the `RETURNING *` clause to execute the query. 
+     * If an {@link SQLException} occurs, an error message is logged to
+     * the standard error stream, including the name of the player associated with the given UUID.</p>
+     * 
+     * @param uuid The unique identifier for the player, represented as a {@link UUID}. This ID is
+     *             used to insert a new record into the `players` table in the database.
+     */
+    public synchronized void addPlayer(UUID uuid) {
+        try (Connection connection = getConnection();
+        PreparedStatement preparedStatement = connection.prepareStatement("INSERT INTO players (uuid) VALUES (?) RETURNING *;")) {
+            
+            preparedStatement.setString(1, uuid.toString());
+            preparedStatement.executeQuery();
         
         } catch (SQLException e) {
-            System.err.println("Could not set the quest version in the db " + e.getMessage());
-        }
-    }
-
-    /**
-     * Gets the SQLite database representation.
-     * @return the playerquests database API.
-     */
-    public static Database getInstance() {
-        return instance;
-    }
-
-    /**
-     * Instantiates or locates a game SQLite database at a URL.
-     * @return an SQLite database connection
-     */
-    public static Connection getConnection() {
-        try {
-            if (connection != null && !connection.isClosed()) {
-                return connection;
-            }
-        } catch (SQLException e) {
-            System.err.println("Could not check if existing connection was closed: " + e.getMessage());
-            return null;
-        }
-
-        try {
-            connection = DriverManager.getConnection("jdbc:sqlite:plugins/PlayerQuests/playerquests.db");
-            return getConnection();
-        } catch (SQLException e) {
-            System.err.println("Could not connect to or create database: " + e.getMessage());
-            return null;
-        }
-    }
-
-    /**
-     * Adds a player to the database.
-     * @param uuid the player UUID
-     * @return the player ID in database
-     */
-    public Integer addPlayer(UUID uuid) {
-        Integer id = getPlayer(uuid);
-
-        if (id != null) {
-            return id;
-        }
-
-        try {
-            // Add player to players table
-            String addPlayerSQL = "INSERT INTO players (uuid) VALUES (?) RETURNING *;";
-
-            PreparedStatement preparedStatement = getConnection().prepareStatement(addPlayerSQL);
-
-            preparedStatement.setString(1, uuid.toString()); // parameterIndex starts at 1
-
-            ResultSet results = preparedStatement.executeQuery();
-            id = results.getInt("id");
-
-            getConnection().close();
-
-            return id;
-
-        } catch (SQLException e) {
             System.err.println("Could not add the user " + Bukkit.getServer().getPlayer(uuid).getName() + ". " + e.getMessage());
-            return null;
         }
     }
-
-    /**
-     * Gets the id associated with a player, from the database.
-     * @param uuid the player UUID
-     * @return the database ID associated with this player
-     */
-    public static Integer getPlayer(UUID uuid) {
-        try {
-            // Add player to players table
-            String addPlayerSQL = "SELECT * FROM players WHERE uuid = ?;";
-
-            PreparedStatement preparedStatement = getConnection().prepareStatement(addPlayerSQL);
-            preparedStatement.setString(1, uuid.toString()); // parameterIndex starts at 1
-
-            ResultSet results = preparedStatement.executeQuery();
-            Integer id = results.getInt("id");
-            Boolean empty = !results.next(); // check if first row exists ("next" is misleading, "first call makes first row current")
+    
+    public synchronized ResultSet getDiary(Integer dbPlayerID) {
+        try (Connection connection = getConnection();
+        PreparedStatement preparedStatement = connection.prepareStatement("SELECT id FROM diaries WHERE player = ?")) {
             
-            getConnection().close();
-
-            if (empty) {
-                return null;
-            }
-
-            return id;
-
+            preparedStatement.setInt(1, dbPlayerID);
+            
+            ResultSet results = preparedStatement.executeQuery();
+            
+            return results;
         } catch (SQLException e) {
-            System.err.println("Could not find the user associated with " + uuid.toString() + ". " + e.getMessage());
+            System.err.println("Could not find a diary for db player ID: " + dbPlayerID + ": " + e.getMessage());
+            return null;
+        }
+    }
+    
+    public synchronized ResultSet getDiaryQuest(String questID, Integer dbDiaryID) {
+        try (Connection connection = getConnection();
+        PreparedStatement preparedStatement = connection.prepareStatement("SELECT * FROM diary_quests WHERE quest = ? AND diary = ?")) {
+            
+            preparedStatement.setString(1, questID);
+            preparedStatement.setInt(2, dbDiaryID);
+            
+            ResultSet result = preparedStatement.executeQuery();
+            
+            return result;
+        } catch (SQLException e) {
+            System.err.println("Could not find quest in the diary: " + questID + ": " + e.getMessage());
             return null;
         }
     }
 
-    public Database addPlayers(List<UUID> uuids) {
-        uuids.stream().forEach(uuid -> {
-            addPlayer(uuid);
-        });
+    public synchronized void setDiaryQuest(QuestDiary diary, Quest quest) {
+        setDiaryQuest(diary, quest, quest.getConnections());
+    }
+    
+    public synchronized void setDiaryQuest(QuestDiary diary, Quest quest, ConnectionsData connections) {
+        String questID = quest.getID(); // get the quest ID
+        Player player = diary.getPlayer(); // get the player this diary represents
 
+        try (Connection connection = getConnection();
+        PreparedStatement preparedStatement = connection.prepareStatement("INSERT OR REPLACE INTO diary_quests (id, stage, action, quest, diary) VALUES (?, ?, ?, ?, ?)")) {
+            
+            preparedStatement.setString(1, player.getUniqueId().toString() + "_" + questID);
+            
+            // default to initial values
+            preparedStatement.setString(2, quest.getEntry().getStage());
+            preparedStatement.setString(3, quest.getEntry().getAction());
+            
+            // get the current quest stage or action
+            StagePath currentConnection = connections.getCurr();
+            
+            // replace with current values (if possible)
+            if (currentConnection != null) {
+                preparedStatement.setString(2, currentConnection.getStage());
+                preparedStatement.setString(3, currentConnection.getAction());
+            }
+            
+            // set remaining values
+            preparedStatement.setString(4, questID);
+            preparedStatement.setString(5, diary.getDiaryID());
+            
+            preparedStatement.execute();
+            
+        } catch (SQLException e) {
+            System.err.println("Could not set or update quest progress for the " + questID + " quest: " + e.getMessage());
+            return;
+        }
+    }
+    
+    public synchronized Database addPlayers(List<UUID> uuids) {
+        for (UUID uuid : uuids) {
+            addPlayer(uuid);
+        }
+        
         return this;
     }
-
-    /**
-     * Gets the id for all quests, as stored in the database.
-     * @return all known quest IDs
-     */
-    public List<String> getAllQuests() {
-        // Create list to add results to
-        List<String> ids = new ArrayList<String>();
-
-        // Get quest IDs from quests table
-        try {
-            Statement statement = getConnection().createStatement();
+    
+    public synchronized List<String> getAllQuests() {
+        List<String> ids = new ArrayList<>();
+        try (Connection connection = getConnection();
+        Statement statement = connection.createStatement()) {
+            
             String allQuestsSQL = "SELECT id FROM quests;";
-
             ResultSet result = statement.executeQuery(allQuestsSQL);
-
-            while(result.next()) {
+            
+            while (result.next()) {
                 ids.add(result.getString("id"));
             }
-
-            return ids;
             
         } catch (SQLException e) {
             System.err.println("Could not retrieve quests from database. " + e.getMessage());
-            return null;
         }
+        return ids;
     }
-
-    /**
-     * Adds a quest reference to the database.
-     * @param id the ID to refer to the quest by
-     */
-    public static void addQuest(String id) {
+    
+    public synchronized void addQuest(String id) {
         if (id == null) {
             return;
         }
-
-        // if the quest already exists in the db, don't continue
-        if (getQuest(id) != null) {
+        
+        String existingId = getQuest(id);
+        
+        if (existingId != null) {
             return;
         }
-
-        try {
-            // Add player to players table
-            String addQuestSQL = "INSERT INTO quests (id) VALUES (?);";
-
-            PreparedStatement preparedStatement = getConnection().prepareStatement(addQuestSQL);
-
-            preparedStatement.setString(1, id); // parameterIndex starts at 1
-
+        try (Connection connection = getConnection();
+        PreparedStatement preparedStatement = connection.prepareStatement("INSERT INTO quests (id) VALUES (?);")) {
+            
+            preparedStatement.setString(1, id);
             preparedStatement.execute();
-
-            getConnection().close();
-
+            
         } catch (SQLException e) {
             System.err.println("Could not add the quest " + id + ". " + e.getMessage());
         }
     }
-
-    /**
-     * Adds a quest reference to the database.
-     * @param id the ID to refer to the quest by
-     */
-    public static String getQuest(String id) {
+    
+    public synchronized String getQuest(String id) {
         if (id == null) {
             return null;
         }
-
-        try {
-            // Add player to players table
-            String addQuestSQL = "SELECT id FROM quests WHERE id = ?;";
-
-            PreparedStatement preparedStatement = getConnection().prepareStatement(addQuestSQL);
-
-            preparedStatement.setString(1, id); // parameterIndex starts at 1
-
+        
+        try (Connection connection = getConnection();
+        PreparedStatement preparedStatement = connection.prepareStatement("SELECT id FROM quests WHERE id = ?;")) {
+            
+            preparedStatement.setString(1, id);
+            
             ResultSet results = preparedStatement.executeQuery();
             String quest = results.getString("id");
-
-            getConnection().close();
-
+            
             return quest;
-
         } catch (SQLException e) {
             System.err.println("Could not get the quest " + id + ". " + e.getMessage());
             return null;
         }
     }
-
-    public static Boolean getQuestToggled(Quest quest) {
-        try {
-            // Add player to players table
-            String addQuestSQL = "SELECT toggled FROM quests WHERE id = ?;";
-
-            PreparedStatement preparedStatement = getConnection().prepareStatement(addQuestSQL);
-
-            preparedStatement.setString(1, quest.getID()); // parameterIndex starts at 1
-
+    
+    public synchronized Boolean getQuestToggled(Quest quest) {
+        try (Connection connection = getConnection();
+        PreparedStatement preparedStatement = connection.prepareStatement("SELECT toggled FROM quests WHERE id = ?;")) {
+            
+            preparedStatement.setString(1, quest.getID());
             ResultSet results = preparedStatement.executeQuery();
-            Boolean state = results.getBoolean("toggled");
-
-            getConnection().close();
-
-            return state;
-
+            Boolean result = false;
+            
+            if (results.next()) {
+                result = results.getBoolean("toggled");
+            }
+            
+            return result; // no result found
         } catch (SQLException e) {
-            System.err.println("Could not get the quest to toggle " + quest.toString() + ". " + e.getMessage());
+            System.err.println("Could not get the quest toggle status " + quest.toString() + ". " + e.getMessage());
             return null;
         }
     }
-
-    public static void setQuestToggled(Quest quest, Boolean state) {
-        try {
-            // Add player to players table
-            String addQuestSQL = "UPDATE quests SET toggled = ? WHERE id = ?;";
-
-            PreparedStatement preparedStatement = getConnection().prepareStatement(addQuestSQL);
-
-            preparedStatement.setBoolean(1, state); // parameterIndex starts at 1
+    
+    // TOOD: fix quest toggling
+    public synchronized void setQuestToggled(Quest quest, Boolean state) {
+        try (Connection connection = getConnection();
+        PreparedStatement preparedStatement = connection.prepareStatement("UPDATE quests SET toggled = ? WHERE id = ?;")) {
+            
+            preparedStatement.setBoolean(1, state);
             preparedStatement.setString(2, quest.getID());
             preparedStatement.execute();
-
-            getConnection().close();
-
-            if (state) {
-                QuestRegistry.getInstance().submit(quest);
-            } else {
-                QuestRegistry.getInstance().remove(quest, true);
-            }
-
+            
         } catch (SQLException e) {
             System.err.println("Could not toggle the quest " + quest.toString() + ". " + e.getMessage());
         }
     }
-
-    /**
-     * Removes a quest reference from the database.
-     * @param id the ID to refer to the quest by
-     */
-    public static void removeQuest(String id) {
+    
+    public synchronized void removeQuest(String id) {
         if (id == null) {
             return;
         }
-
-        try {
+        
+        try (Connection connection = getConnection()) {
             PreparedStatement preparedStatement;
-
-            // Remove quest from quests table
+            
             String removeQuestSQL = "DELETE FROM quests WHERE id = ?;";
             preparedStatement = getConnection().prepareStatement(removeQuestSQL);
             preparedStatement.setString(1, id);
             preparedStatement.execute();
-
-            // Remove quest reference from quest diaries
+            
             String removeDiaryQuestSQL = "DELETE FROM diary_quests WHERE quest = ?;";
             preparedStatement = getConnection().prepareStatement(removeDiaryQuestSQL);
             preparedStatement.setString(1, id);
             preparedStatement.execute();
-
-            getConnection().close();
-        
+            
         } catch (SQLException e) {
             System.err.println("Could not remove the quest " + id + ". " + e.getMessage());
         }
     }
+
+    /**
+     * Inserts or adds a player {@link QuestDiary} to the database.
+     * 
+     * This method takes a {@link QuestDiary} object, extracts the player ID from it, and uses
+     * this ID to insert or replace an existing record in the `diaries` table of the database. The
+     * database operation is performed within a try-with-resources block to ensure proper resource
+     * management. If an {@link SQLException} occurs, an error message is logged to the standard error stream.
+     * 
+     * Note: The method assumes that the `diaries` table has a column named `player` where the
+     * player ID is stored. It uses an SQL `INSERT OR REPLACE` statement to handle both insertion of
+     * new records and updating of existing records.
+     * 
+     * @param questDiary The {@link QuestDiary} instance containing the diary information to be
+     *                   inserted or updated in the database. The player ID is extracted from this
+     *                   object and used to identify the corresponding record in the `diaries` table.
+     */
+    public synchronized void addDiary(QuestDiary questDiary) {
+        try (Connection connection = getConnection();
+            PreparedStatement preparedStatement = connection.prepareStatement("INSERT OR REPLACE INTO diaries (id, player) VALUES (?, ?)")) {
+            
+            preparedStatement.setString(1, questDiary.getDiaryID());
+            preparedStatement.setString(2, questDiary.getPlayerID());
+            
+            preparedStatement.execute();
+            
+        } catch (SQLException e) {
+            System.err.println("Could not create a diary for: " + questDiary.getPlayerID() + ": " + e.getMessage());
+        }
+    }
+
+	public synchronized Map<Quest,ConnectionsData> getQuestProgress(QuestDiary questDiary) {
+        Map<Quest,ConnectionsData> progress = new HashMap<Quest,ConnectionsData>();
+        
+		try (Connection connection = getConnection();
+        PreparedStatement preparedStatement = connection.prepareStatement("SELECT * FROM diary_quests WHERE diary = ?")) {
+            
+            preparedStatement.setString(1, questDiary.getDiaryID());
+            
+            ResultSet results = preparedStatement.executeQuery();
+
+            while (results.next()) {
+                Quest quest = Core.getQuestRegistry().getQuest(results.getString("quest"));
+
+                if (quest == null) {
+                    continue; // skip to next
+                }
+
+                QuestStage stage = quest.getStages().get(results.getString("stage"));
+                QuestAction action = stage.getActions().get(results.getString("action"));
+
+                progress.put(
+                    quest, // put the quest if found
+                    new ConnectionsData(
+                        null, 
+                        new StagePath(stage, action), 
+                        null
+                    )
+                );
+            }
+
+            return progress;
+            
+        } catch (SQLException e) {
+            System.err.println("Could not find quest progress in db for " + questDiary.getPlayer() + ": " + e.getMessage());
+            return null;
+        }
+	}
 }

--- a/src/main/java/playerquests/utility/singleton/PlayerQuests.java
+++ b/src/main/java/playerquests/utility/singleton/PlayerQuests.java
@@ -1,11 +1,15 @@
 package playerquests.utility.singleton;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.bukkit.Location; // the minecraft location object
 import org.bukkit.World; // the minecraft world
 import org.bukkit.block.Block; // the minecraft block
 
 import playerquests.builder.quest.npc.BlockNPC; // a block representing an NPC
 import playerquests.builder.quest.npc.QuestNPC; // core NPC object/data
+import playerquests.client.Director; // generic director type
 import playerquests.product.Quest; // represents a quest product
 import playerquests.utility.listener.BlockListener; // for block-related events
 import playerquests.utility.listener.PlayerListener; // for player-related events
@@ -64,6 +68,11 @@ public class PlayerQuests {
     }
 
     /**
+     * List of directors.
+     */
+    private List<Director> directors = new ArrayList<Director>();
+
+    /**
      * Puts the block in the world and registers
      * it as an NPC.
      * @param blockNPC the block details of an npc
@@ -101,5 +110,24 @@ public class PlayerQuests {
         // remove all NPCs
         blockListener.remove(quest);
     }
-    
+
+    public void addDirector(Director director) {
+        this.directors.add(director);
+    }
+
+    /**
+     * Clear each part of the quest.
+     * 
+     * Clear the QuestRegistry to ensure no quests are left 
+     * in memory or are in an inconsistent state after the plugin
+     * is disabled. This is for maintaining the integrity 
+     * of the quest data and preventing memory leaks.
+     */
+    public void clear() {
+        QuestRegistry.getInstance().clear();
+        directors.removeIf(director -> {
+            director.close();  // Close the director
+            return true;       // Remove the entry
+        });
+    }
 }

--- a/src/main/resources/quest/templates/beans-tester-bonus.json
+++ b/src/main/resources/quest/templates/beans-tester-bonus.json
@@ -43,7 +43,7 @@
           "npc" : "npc_0",
           "dialogue" : [ "I'm Beans the Acacia Log (^^)" ],
           "connections" : {
-            "next" : "action_1",
+            "next" : "stage_0.action_1",
             "curr" : null,
             "prev" : null
           },
@@ -55,17 +55,17 @@
           "npc" : "npc_1",
           "dialogue" : [ "No! I'm the real Beans!!" ],
           "connections" : {
-            "next" : "action_0",
+            "next" : "stage_0.action_0",
             "curr" : null,
             "prev" : null
           },
           "id" : "action_1"
         }
       },
-      "entry" : "action_0",
+      "entry" : "stage_0.action_0",
       "connections" : {
         "next" : null,
-        "curr" : "action_0",
+        "curr" : "stage_0.action_0",
         "prev" : null
       }
     }


### PR DESCRIPTION
… (#76)

* increase myquests slots

35 leaves one blank, 36 fills all except the bottom row

* increment version: 0.5 -> 0.5.1

* fix UI blocking when loading new quests in myquests

* added stability to fix

* add registering fs+db quests at onLoad

* fixed onLoad quest fs exception message

* add tolerance for instantiating without a demo quest

adds creating quest template dir at start always

* add comment for handling RELOAD

* fixed complexity of myquests loading

breaks the in-game/realtime database/data folders init. Also requires reload for new quest files (this can be addressed by attaching some fs watcher elsewhere, that would be more efficient)

* fixed overcorrecting in myquests

will move data correction to a watcher, probably in ServerListener. Will be more performant, and way more out of your face/overcomplicated.

* fixed monolithic ServerListener.onLoad

* add early outline for fs watch-and-repair

also includes making the ServerListener less untidy + using onDisable over ServerLoadEvent.RELOAD, as a more reliable method. We still need to implement the repair part of the watch-and-repair.

* add quest auto submit and delete (w/ fs watcher)

* fix small concurrency issues in db write/read

* fixed some delays with synchronous code (breaks some things due to db locking)

see issue #67 for fixing the regression in this commit

* added QuestClient/QuestDiary data caching

Previously the data for Quests would all come from the database, but this went bad when too many tasks were happening and there were concurrency issues; #67. There are still concurrency issues, but it no longer breaks usage (just restoring data from previous session after reloads/restarts). The database now should only be used for 'preserving' state between reloads/restarts. It would make sense to maybe just run the Database on one thread, all in order (but idk, that's my assumption ~ maybe other things like transactions would be fine but not that i know of immediately).

* add db migration query for v0.5.1

* fixed capturing other player input in SelectBlock

* fixed NPC block break + retoggling

* fixed saving when removing action from stage

* fixed quest toggling

* fix quest untoggling after reload

fixes #70

* add informative Quest string representation

shows the [class + class hash = quest id]

* fixed in-world (Block) NPCs carrying old Quest references

An older reference to a quest that has now been replaced with a new reference, is effectively a different quest and so shows duplicated actions. Fixes #72

* patch incorrect quest fetched on NPC interaction (inefficient)

inefficient patch for #73

* fix incorrect quest fetched on NPC interaction

improvement over bb323b7 for issue #73, closes #73

* fixed listening for all player messages in ChatPrompt

* fixed listening for all player block placing in SelectLocation

* fixed cancelling chat when chat is a denied select method in SelectBlock

to explain this: SelectBlock has select by Chat, select by Hit and select by Inventory. Those aren't the exact things, check SelectMethod if you want to see the actual ones. But basically, the chat listener didn't know it should allow chat to not be cancelled if it's not an allowed method of selecting a block.

* remove redundant closes when using try-with-resources

* fixed concurrency issues with database

this marks durable quest progress and data, despite reloads and restarts

* remove quest progress tracking debug console logs

* fixed un-started quests never added to new player quest diaries

* remove TODO: un-started quest duplication testing

* fix GUI clicks running for other players

* add closing GUI on server reload

saves from being able to take items from the GUI when it's no longer being listened to.

* fixed stage adding increment

stage_11 -> stage_2

* add StagePath for quest pointers

For example something like action_0, is now stage_0.action_0. Obvious reason being how would you know otherwise whether it's action_0 in stage_0 or action_0 in stage_1. Fixes #74

* fix incorrect getAction() return value for StagePath classes

* remove double-up: adding quests to each players 'Quest Diary'

Fixes an issue where if you join super early or reload a little unlucky, it will put a Quest into your diary based on the start of the quest (even if you have progress). This change works because QuestDiary's load the quests into themselves (when they are ready, since conveniently QuestRegistry is a neatly accessible singleton).

* fix unordered stages list in Quest Stages menu

This would break creating new stages

* increase quest stages limit to 42

* explicitly cap quest actions limit to 12

this is a good thing to change, with the proper support for changing it

* create quest refund (w/ usage on quest deletion)

* refund NPC on remove/re-assign

* add alerting when latest release doesn't match current