### PR TITLE
Fix release alert always showing

### DIFF
--- a/src/main/java/playerquests/utility/singleton/Database.java
+++ b/src/main/java/playerquests/utility/singleton/Database.java
@@ -196,6 +196,7 @@ public class Database {
             StringBuilder query = new StringBuilder();
             
             switch (version) {
+                case "0.5.2":
                 case "0.5.1":
                     query.append(MigrationUtils.dbV0_5_1());
                 case "0.5":

--- a/src/main/java/playerquests/utility/singleton/Database.java
+++ b/src/main/java/playerquests/utility/singleton/Database.java
@@ -175,8 +175,8 @@ public class Database {
             String latest = tree.findValue("tag_name").textValue(); // get latest tag_name (for example "v0.5")
 
             // Alert if latest version is different to current
-            // (this will happen on snapshots too, but the compute for this edge case doesn't seem worthwhile)
-            if ("v"+version != latest) {
+            // (this could happen on snapshots, but the compute for this edge case doesn't seem worthwhile)
+            if (!("v"+version).equals(latest)) {
                 alert.content("A new release is available! " + latest)
                     .send();
             }


### PR DESCRIPTION
Just uses a different comparator (equivalency operator to .equals function) and more specific parantheses for grouping operations.

This only fixes the issue for releases. If you're on a snapshot, it will report a new version that is older than your current. For example: 0.5.3 it will say the new release is 0.5.2. This is because there isn't a function to evaluate the string as a version. It's just a simple and fast check if the current version is the same as the latest release.

I'm happy with snapshots being a fringe case, they are snapshots after all which shouldn't be considered stable. So an alert pulling back to 'newest' release is fairly appropriate.

Closes #79 