### PR TITLE
Add more exit conditions to interactive functions

### DIFF
--- a/src/main/java/playerquests/builder/gui/function/ChatPrompt.java
+++ b/src/main/java/playerquests/builder/gui/function/ChatPrompt.java
@@ -7,6 +7,7 @@ import org.bukkit.event.EventHandler; // handling spigot events
 import org.bukkit.event.HandlerList; // to unregister event listener (ChatPromptListener)
 import org.bukkit.event.Listener; // to register event listener (ChatPromptListener)
 import org.bukkit.event.player.AsyncPlayerChatEvent;
+import org.bukkit.event.player.PlayerCommandPreprocessEvent;
 import org.bukkit.ChatColor; // used to format the chat messages to guide user input/UX
 import org.bukkit.entity.HumanEntity; // usually the player
 import org.bukkit.entity.Player; // refers to the player
@@ -43,6 +44,19 @@ public class ChatPrompt extends GUIFunction {
         public ChatPromptListener(ChatPrompt parent, Player player) {
             this.parentClass = parent;
             this.player = player;
+        }
+
+        @EventHandler
+        private void onCommand(PlayerCommandPreprocessEvent event) {
+            // do not capture other players events
+            if (this.player != event.getPlayer()) {
+                return;
+            }
+
+            // exit ChatPrompt
+            Bukkit.getScheduler().runTask(Core.getPlugin(), () -> { // run on next tick
+                this.parentClass.exit();
+            });
         }
 
         /**

--- a/src/main/java/playerquests/builder/gui/function/SelectBlock.java
+++ b/src/main/java/playerquests/builder/gui/function/SelectBlock.java
@@ -98,24 +98,30 @@ public class SelectBlock extends GUIFunction {
 
         @EventHandler
         private void onChat(AsyncPlayerChatEvent event) {
+            // if the event is coming from a different player
             if (this.player != event.getPlayer()) {
                 return; // do not capture other players events
-            }
-
-            if (deniedMethods.contains(SelectMethod.CHAT)) {
-                return; // do not continue
             }
 
             event.setCancelled(true);
 
             Bukkit.getScheduler().runTask(Core.getPlugin(), () -> { // run on next tick
-                if (event.getMessage().toLowerCase().equals("exit")) { // if wanting to exit
+                String message = event.getMessage();
+
+                // if wanting to exit (or trying to do another command)
+                if (message.toLowerCase().equals("exit")) {
                     this.parentClass.setCancelled(true);
                     this.parentClass.execute(); // run with cancellation
-                } else { // if trying to set a block using the chat box
-                    if (!deniedMethods.contains(SelectMethod.CHAT)) { // if CHAT mode enabled
-                        this.parentClass.setResponse(event.getMessage()); // set
-                    }
+                }
+
+                // if selecting block with chat is not allowed
+                if (deniedMethods.contains(SelectMethod.CHAT)) {
+                    return; // do not continue
+                }
+
+                // if trying to set a block using the chat box
+                if (!deniedMethods.contains(SelectMethod.CHAT)) { // if CHAT mode enabled
+                    this.parentClass.setResponse(message); // set
                 }
             });
         }

--- a/src/main/java/playerquests/builder/gui/function/SelectBlock.java
+++ b/src/main/java/playerquests/builder/gui/function/SelectBlock.java
@@ -15,6 +15,7 @@ import org.bukkit.event.HandlerList; // unregistering event handlers
 import org.bukkit.event.Listener; // listening to in-game events
 import org.bukkit.event.inventory.InventoryClickEvent; // for detecting block selections in listener
 import org.bukkit.event.player.AsyncPlayerChatEvent; // handling request to exit
+import org.bukkit.event.player.PlayerCommandPreprocessEvent;
 import org.bukkit.event.player.PlayerInteractEvent; // for detecting block hits in listener
 
 import playerquests.Core; // accessing singletons
@@ -93,6 +94,20 @@ public class SelectBlock extends GUIFunction {
                 
                 event.getView().close();
                 parentClass.setResponse(event.getCurrentItem().getType());
+            });
+        }
+
+        @EventHandler
+        private void onCommand(PlayerCommandPreprocessEvent event) {
+            // do not capture other players events
+            if (this.player != event.getPlayer()) {
+                return;
+            }
+
+            // exit SelectBlock
+            Bukkit.getScheduler().runTask(Core.getPlugin(), () -> { // run on next tick
+                this.parentClass.setCancelled(true);
+                this.parentClass.execute(); // run with cancellation
             });
         }
 

--- a/src/main/java/playerquests/builder/gui/function/SelectLocation.java
+++ b/src/main/java/playerquests/builder/gui/function/SelectLocation.java
@@ -13,6 +13,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockPlaceEvent; // event which captures what block was placed
+import org.bukkit.event.player.PlayerCommandPreprocessEvent;
 
 import playerquests.Core;
 import playerquests.builder.quest.data.LocationData; // quest entity locations
@@ -44,6 +45,19 @@ public class SelectLocation extends GUIFunction {
         public SelectLocationListener(SelectLocation parent, Player player) {
             this.parentClass = parent;
             this.player = player;
+        }
+
+        @EventHandler
+        private void onCommand(PlayerCommandPreprocessEvent event) {
+            // do not capture other players events
+            if (this.player != event.getPlayer()) {
+                return;
+            }
+
+            // exit SelectLocation
+            Bukkit.getScheduler().runTask(Core.getPlugin(), () -> { // run on next tick
+                this.parentClass.exit();
+            });
         }
 
         @EventHandler

--- a/src/main/java/playerquests/builder/gui/function/SelectLocation.java
+++ b/src/main/java/playerquests/builder/gui/function/SelectLocation.java
@@ -205,12 +205,12 @@ public class SelectLocation extends GUIFunction {
      * @return a bukkit BlockData type
      */
     public BlockData getBlockData() {
-        if (this.blockData != null) {
-            return this.blockData;
+        if (this.blockData == null) {
+            System.err.println("The block was requested from LocationData, without a block having been set.");
+            
         }
-
-        System.err.println("The block was requested from LocationData, without a block having been set.");
-        return Material.BARRIER.createBlockData(); // give a default, instead of failing
+        
+        return this.blockData;
     }
 
     /**


### PR DESCRIPTION
This makes things like 'ChatPrompt', 'SelectBlock' and 'SelectLocation' more resilient.

It does this by exiting them when **any** command is done, to avoid conflicts. (Especially with others plugins which may operate in unknown ways).

It also fixes #86 